### PR TITLE
Handle Substitution types better

### DIFF
--- a/src/parsers/typeResolver.ts
+++ b/src/parsers/typeResolver.ts
@@ -394,6 +394,18 @@ function resolveTypeUncached(
 			return new IntrinsicNode('any', typeName);
 		}
 
+		// SubstitutionTypes are checker-internal placeholders created while TypeScript
+		// evaluates conditional/infer/mapped types. They represent "baseType, but
+		// under this constraint" rather than a syntax form we can emit directly.
+		// Prefer a clean representation of the base/constraint over falling back to
+		// `any`, but only when resolving it does not itself hit another unsupported type.
+		if (hasExactFlag(type, ts.TypeFlags.Substitution)) {
+			const substitutionFallback = resolveSubstitutionFallback(type, context);
+			if (substitutionFallback) {
+				return substitutionFallback;
+			}
+		}
+
 		unsupportedFallbackTypes.add(type);
 		reportUnsupportedTypeFallback(type, typeNode, context);
 
@@ -404,6 +416,44 @@ function resolveTypeUncached(
 			typeStack.pop();
 		}
 	}
+}
+
+function resolveSubstitutionFallback(type: ts.Type, context: ParserContext): AnyType | undefined {
+	const substitutionType = type as ts.SubstitutionType;
+
+	return (
+		resolveSubstitutionCandidate(substitutionType.baseType, context) ??
+		resolveSubstitutionCandidate(substitutionType.constraint, context)
+	);
+}
+
+function resolveSubstitutionCandidate(
+	candidateType: ts.Type,
+	context: ParserContext,
+): AnyType | undefined {
+	if (hasExactFlag(candidateType, ts.TypeFlags.Substitution)) {
+		return undefined;
+	}
+
+	// This is a probe, not the real fallback path. If the candidate still needs
+	// an unsupported-type warning, reject it and let the original substitution
+	// report a single warning with the best source location.
+	const warnings: unknown[] = [];
+	const onWarning = context.onWarning;
+	context.onWarning = (warning) => {
+		warnings.push(warning);
+	};
+
+	try {
+		const resolvedCandidate = resolveType(candidateType, undefined, context);
+		return warnings.length === 0 && !isAnyNode(resolvedCandidate) ? resolvedCandidate : undefined;
+	} finally {
+		context.onWarning = onWarning;
+	}
+}
+
+function isAnyNode(typeNode: AnyType): boolean {
+	return typeNode instanceof IntrinsicNode && typeNode.intrinsic === 'any' && !typeNode.typeName;
 }
 
 const allowedBuiltInTsTypes = new Set([

--- a/src/parsers/typeResolver.ts
+++ b/src/parsers/typeResolver.ts
@@ -143,9 +143,21 @@ function resolveTypeUncached(
 			typeName = getFullName(type, typeNode, context);
 		}
 
+		const replayNameResolutionWarnings = () => {
+			for (const warning of nameResolutionWarnings) {
+				context.onWarning(warning);
+			}
+			nameResolutionWarnings.length = 0;
+		};
+
+		const returnWithNameResolutionWarnings = <T extends AnyType>(resolvedType: T): T => {
+			replayNameResolutionWarnings();
+			return resolvedType;
+		};
+
 		// If this type was already on the stack, return a shallow version with type info but no properties
 		if (isAlreadyOnStack) {
-			return createShallowType(type, typeName, checker);
+			return returnWithNameResolutionWarnings(createShallowType(type, typeName, checker));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.TypeParameter) && type.symbol) {
@@ -160,7 +172,7 @@ function resolveTypeUncached(
 					// Get the type from the symbol's declaration
 					const symbolType = checker.getDeclaredTypeOfSymbol(symbol);
 					if (symbolType && !hasExactFlag(symbolType, ts.TypeFlags.TypeParameter)) {
-						return resolveType(symbolType, typeNode, context);
+						return returnWithNameResolutionWarnings(resolveType(symbolType, typeNode, context));
 					}
 				}
 			}
@@ -170,23 +182,27 @@ function resolveTypeUncached(
 				? checker.getBaseConstraintOfType(type)
 				: undefined;
 
-			return new TypeParameterNode(
-				type.symbol.name,
-				constraintType ? resolveType(constraintType, undefined, context) : undefined,
-				declaration?.default
-					? resolveType(checker.getTypeAtLocation(declaration.default), undefined, context)
-					: undefined,
+			return returnWithNameResolutionWarnings(
+				new TypeParameterNode(
+					type.symbol.name,
+					constraintType ? resolveType(constraintType, undefined, context) : undefined,
+					declaration?.default
+						? resolveType(checker.getTypeAtLocation(declaration.default), undefined, context)
+						: undefined,
+				),
 			);
 		}
 
 		if (checker.isArrayType(type)) {
 			// @ts-expect-error - Private method
 			const arrayType: ts.Type = checker.getElementTypeOfArrayType(type);
-			return new ArrayNode(
-				type.aliasSymbol?.name
-					? new TypeName(type.aliasSymbol?.name, typeName?.namespaces, typeName?.typeArguments)
-					: undefined,
-				resolveType(arrayType, undefined, context),
+			return returnWithNameResolutionWarnings(
+				new ArrayNode(
+					type.aliasSymbol?.name
+						? new TypeName(type.aliasSymbol?.name, typeName?.namespaces, typeName?.typeArguments)
+						: undefined,
+					resolveType(arrayType, undefined, context),
+				),
 			);
 		}
 
@@ -222,27 +238,29 @@ function resolveTypeUncached(
 			}
 
 			if (!externalTypeName) {
-				return new IntrinsicNode('any');
+				return returnWithNameResolutionWarnings(new IntrinsicNode('any'));
 			}
 
 			// Fixes a weird TS behavior where it doesn't show the alias name but resolves to the actual type in case of RefCallback.
 			if (externalTypeName === 'bivarianceHack') {
-				return new ExternalTypeNode(
-					new TypeName('RefCallback', ['React'], typeName?.typeArguments),
+				return returnWithNameResolutionWarnings(
+					new ExternalTypeNode(new TypeName('RefCallback', ['React'], typeName?.typeArguments)),
 				);
 			}
 
-			return new ExternalTypeNode(
-				new TypeName(externalTypeName, typeName?.namespaces, typeName?.typeArguments),
+			return returnWithNameResolutionWarnings(
+				new ExternalTypeNode(
+					new TypeName(externalTypeName, typeName?.namespaces, typeName?.typeArguments),
+				),
 			);
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.Boolean)) {
-			return new IntrinsicNode('boolean');
+			return returnWithNameResolutionWarnings(new IntrinsicNode('boolean'));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.Void)) {
-			return new IntrinsicNode('void');
+			return returnWithNameResolutionWarnings(new IntrinsicNode('void'));
 		}
 
 		if (includesCompositeFlag(type, ts.TypeFlags.EnumLike)) {
@@ -253,14 +271,14 @@ function resolveTypeUncached(
 			}
 
 			if (!symbol) {
-				return new IntrinsicNode('any');
+				return returnWithNameResolutionWarnings(new IntrinsicNode('any'));
 			}
 
-			return parseEnum(symbol, context);
+			return returnWithNameResolutionWarnings(parseEnum(symbol, context));
 		}
 
 		if (type.isUnion()) {
-			return resolveUnionType(type, typeName, typeNode, context);
+			return returnWithNameResolutionWarnings(resolveUnionType(type, typeName, typeNode, context));
 		}
 
 		if (type.isIntersection()) {
@@ -275,52 +293,57 @@ function resolveTypeUncached(
 			}
 
 			if (memberTypes.length === 1) {
-				return memberTypes[0];
+				return returnWithNameResolutionWarnings(memberTypes[0]);
 			}
 
 			if (memberTypes.length > 1) {
 				const callSignatures = type.getCallSignatures();
 				if (callSignatures.length >= 1) {
-					return parseFunctionType(type, context)!;
+					return returnWithNameResolutionWarnings(parseFunctionType(type, context)!);
 				}
 
 				const objectType = parseObjectType(type, typeName, context, resolveType);
 				if (objectType) {
-					return new IntersectionNode(typeName, memberTypes, objectType.properties);
+					return returnWithNameResolutionWarnings(
+						new IntersectionNode(typeName, memberTypes, objectType.properties),
+					);
 				}
 
-				return new IntersectionNode(typeName, memberTypes, []);
+				return returnWithNameResolutionWarnings(new IntersectionNode(typeName, memberTypes, []));
 			}
 		}
 
 		if (checker.isTupleType(type)) {
-			return new TupleNode(
-				typeName,
-				(type as ts.TupleType).typeArguments?.map((x) => resolveType(x, undefined, context)) ?? [],
+			return returnWithNameResolutionWarnings(
+				new TupleNode(
+					typeName,
+					(type as ts.TupleType).typeArguments?.map((x) => resolveType(x, undefined, context)) ??
+						[],
+				),
 			);
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.String)) {
-			return new IntrinsicNode('string');
+			return returnWithNameResolutionWarnings(new IntrinsicNode('string'));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.Number)) {
-			return new IntrinsicNode('number');
+			return returnWithNameResolutionWarnings(new IntrinsicNode('number'));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.BigInt)) {
-			return new IntrinsicNode('bigint');
+			return returnWithNameResolutionWarnings(new IntrinsicNode('bigint'));
 		}
 
 		if (
 			hasExactFlag(type, ts.TypeFlags.ESSymbol) ||
 			hasExactFlag(type, ts.TypeFlags.UniqueESSymbol)
 		) {
-			return new IntrinsicNode('symbol', typeName);
+			return returnWithNameResolutionWarnings(new IntrinsicNode('symbol', typeName));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.Undefined)) {
-			return new IntrinsicNode('undefined');
+			return returnWithNameResolutionWarnings(new IntrinsicNode('undefined'));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.Any)) {
@@ -335,29 +358,31 @@ function resolveTypeUncached(
 					// Recursively resolve, passing the memberTypeNode so alias information is preserved
 					unionTypes.push(resolveType(memberType, memberTypeNode, context));
 				}
-				return new UnionNode(typeName, unionTypes);
+				return returnWithNameResolutionWarnings(new UnionNode(typeName, unionTypes));
 			}
-			return new IntrinsicNode('any', typeName);
+			return returnWithNameResolutionWarnings(new IntrinsicNode('any', typeName));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.Unknown)) {
-			return new IntrinsicNode('unknown', typeName);
+			return returnWithNameResolutionWarnings(new IntrinsicNode('unknown', typeName));
 		}
 
 		if (includesCompositeFlag(type, ts.TypeFlags.Literal)) {
 			if (type.isLiteral()) {
-				return new LiteralNode(
-					type.isStringLiteral() ? `"${type.value}"` : type.value,
-					typeName,
-					getDocumentationFromSymbol(type.symbol, checker),
+				return returnWithNameResolutionWarnings(
+					new LiteralNode(
+						type.isStringLiteral() ? `"${type.value}"` : type.value,
+						typeName,
+						getDocumentationFromSymbol(type.symbol, checker),
+					),
 				);
 			}
 
-			return new LiteralNode(checker.typeToString(type));
+			return returnWithNameResolutionWarnings(new LiteralNode(checker.typeToString(type)));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.Null)) {
-			return new IntrinsicNode('null');
+			return returnWithNameResolutionWarnings(new IntrinsicNode('null'));
 		}
 
 		// TODO: currently types can be either a "function" or an "object" but not both.
@@ -365,7 +390,7 @@ function resolveTypeUncached(
 		// Consider creating a new type that can handle both.
 		const callSignatures = type.getCallSignatures();
 		if (callSignatures.length >= 1) {
-			return parseFunctionType(type, context)!;
+			return returnWithNameResolutionWarnings(parseFunctionType(type, context)!);
 		}
 
 		// Check for class types (have construct signatures)
@@ -373,13 +398,13 @@ function resolveTypeUncached(
 		if (constructSignatures.length >= 1) {
 			const classType = parseClassType(type, context);
 			if (classType) {
-				return classType;
+				return returnWithNameResolutionWarnings(classType);
 			}
 		}
 
 		const objectType = parseObjectType(type, typeName, context, resolveType);
 		if (objectType) {
-			return objectType;
+			return returnWithNameResolutionWarnings(objectType);
 		}
 
 		// Object without properties or object keyword
@@ -387,11 +412,11 @@ function resolveTypeUncached(
 			hasExactFlag(type, ts.TypeFlags.Object) ||
 			(hasExactFlag(type, ts.TypeFlags.NonPrimitive) && checker.typeToString(type) === 'object')
 		) {
-			return new ObjectNode(typeName, [], undefined);
+			return returnWithNameResolutionWarnings(new ObjectNode(typeName, [], undefined));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.Never)) {
-			return new IntrinsicNode('never', typeName);
+			return returnWithNameResolutionWarnings(new IntrinsicNode('never', typeName));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.Conditional)) {

--- a/src/parsers/typeResolver.ts
+++ b/src/parsers/typeResolver.ts
@@ -113,14 +113,41 @@ function resolveTypeUncached(
 		typeStack.push(typeId);
 	}
 
-	const typeName = getFullName(type, typeNode, context);
-
-	// If this type was already on the stack, return a shallow version with type info but no properties
-	if (isAlreadyOnStack) {
-		return createShallowType(type, typeName, checker);
-	}
+	let typeName: TypeName | undefined;
 
 	try {
+		// SubstitutionTypes are checker-internal placeholders created while TypeScript
+		// evaluates conditional/infer/mapped types. They represent "baseType, but
+		// under this constraint" rather than a syntax form we can emit directly.
+		// Try this before getFullName(), which may resolve type arguments and emit
+		// warnings that would be misleading if the substitution fallback succeeds.
+		if (!isAlreadyOnStack && hasExactFlag(type, ts.TypeFlags.Substitution)) {
+			const substitutionFallback = resolveSubstitutionFallback(type, context);
+			if (substitutionFallback) {
+				return substitutionFallback;
+			}
+		}
+
+		const nameResolutionWarnings: Array<Parameters<ParserContext['onWarning']>[0]> = [];
+		if (hasExactFlag(type, ts.TypeFlags.Conditional)) {
+			const onWarning = context.onWarning;
+			context.onWarning = (warning) => {
+				nameResolutionWarnings.push(warning);
+			};
+			try {
+				typeName = getFullName(type, typeNode, context);
+			} finally {
+				context.onWarning = onWarning;
+			}
+		} else {
+			typeName = getFullName(type, typeNode, context);
+		}
+
+		// If this type was already on the stack, return a shallow version with type info but no properties
+		if (isAlreadyOnStack) {
+			return createShallowType(type, typeName, checker);
+		}
+
 		if (hasExactFlag(type, ts.TypeFlags.TypeParameter) && type.symbol) {
 			// If we have a typeNode, check if it resolves to a more concrete type than the TypeParameter.
 			// This handles cases where TypeScript doesn't fully instantiate generic parameters,
@@ -394,19 +421,10 @@ function resolveTypeUncached(
 			return new IntrinsicNode('any', typeName);
 		}
 
-		// SubstitutionTypes are checker-internal placeholders created while TypeScript
-		// evaluates conditional/infer/mapped types. They represent "baseType, but
-		// under this constraint" rather than a syntax form we can emit directly.
-		// Prefer a clean representation of the base/constraint over falling back to
-		// `any`, but only when resolving it does not itself hit another unsupported type.
-		if (hasExactFlag(type, ts.TypeFlags.Substitution)) {
-			const substitutionFallback = resolveSubstitutionFallback(type, context);
-			if (substitutionFallback) {
-				return substitutionFallback;
-			}
-		}
-
 		unsupportedFallbackTypes.add(type);
+		for (const warning of nameResolutionWarnings) {
+			context.onWarning(warning);
+		}
 		reportUnsupportedTypeFallback(type, typeNode, context);
 
 		return new IntrinsicNode('any', typeName);

--- a/src/parsers/typeResolver.ts
+++ b/src/parsers/typeResolver.ts
@@ -150,14 +150,16 @@ function resolveTypeUncached(
 			nameResolutionWarnings.length = 0;
 		};
 
-		const returnWithNameResolutionWarnings = <T extends AnyType>(resolvedType: T): T => {
+		// Conditional type name resolution may emit warnings for type arguments.
+		// Replay them only on return paths that keep the computed typeName.
+		const withNameResolutionWarnings = <T extends AnyType>(resolvedType: T): T => {
 			replayNameResolutionWarnings();
 			return resolvedType;
 		};
 
 		// If this type was already on the stack, return a shallow version with type info but no properties
 		if (isAlreadyOnStack) {
-			return returnWithNameResolutionWarnings(createShallowType(type, typeName, checker));
+			return withNameResolutionWarnings(createShallowType(type, typeName, checker));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.TypeParameter) && type.symbol) {
@@ -172,7 +174,7 @@ function resolveTypeUncached(
 					// Get the type from the symbol's declaration
 					const symbolType = checker.getDeclaredTypeOfSymbol(symbol);
 					if (symbolType && !hasExactFlag(symbolType, ts.TypeFlags.TypeParameter)) {
-						return returnWithNameResolutionWarnings(resolveType(symbolType, typeNode, context));
+						return withNameResolutionWarnings(resolveType(symbolType, typeNode, context));
 					}
 				}
 			}
@@ -182,7 +184,7 @@ function resolveTypeUncached(
 				? checker.getBaseConstraintOfType(type)
 				: undefined;
 
-			return returnWithNameResolutionWarnings(
+			return withNameResolutionWarnings(
 				new TypeParameterNode(
 					type.symbol.name,
 					constraintType ? resolveType(constraintType, undefined, context) : undefined,
@@ -196,7 +198,7 @@ function resolveTypeUncached(
 		if (checker.isArrayType(type)) {
 			// @ts-expect-error - Private method
 			const arrayType: ts.Type = checker.getElementTypeOfArrayType(type);
-			return returnWithNameResolutionWarnings(
+			return withNameResolutionWarnings(
 				new ArrayNode(
 					type.aliasSymbol?.name
 						? new TypeName(type.aliasSymbol?.name, typeName?.namespaces, typeName?.typeArguments)
@@ -238,17 +240,17 @@ function resolveTypeUncached(
 			}
 
 			if (!externalTypeName) {
-				return returnWithNameResolutionWarnings(new IntrinsicNode('any'));
+				return withNameResolutionWarnings(new IntrinsicNode('any'));
 			}
 
 			// Fixes a weird TS behavior where it doesn't show the alias name but resolves to the actual type in case of RefCallback.
 			if (externalTypeName === 'bivarianceHack') {
-				return returnWithNameResolutionWarnings(
+				return withNameResolutionWarnings(
 					new ExternalTypeNode(new TypeName('RefCallback', ['React'], typeName?.typeArguments)),
 				);
 			}
 
-			return returnWithNameResolutionWarnings(
+			return withNameResolutionWarnings(
 				new ExternalTypeNode(
 					new TypeName(externalTypeName, typeName?.namespaces, typeName?.typeArguments),
 				),
@@ -256,11 +258,11 @@ function resolveTypeUncached(
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.Boolean)) {
-			return returnWithNameResolutionWarnings(new IntrinsicNode('boolean'));
+			return withNameResolutionWarnings(new IntrinsicNode('boolean'));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.Void)) {
-			return returnWithNameResolutionWarnings(new IntrinsicNode('void'));
+			return withNameResolutionWarnings(new IntrinsicNode('void'));
 		}
 
 		if (includesCompositeFlag(type, ts.TypeFlags.EnumLike)) {
@@ -271,14 +273,14 @@ function resolveTypeUncached(
 			}
 
 			if (!symbol) {
-				return returnWithNameResolutionWarnings(new IntrinsicNode('any'));
+				return withNameResolutionWarnings(new IntrinsicNode('any'));
 			}
 
-			return returnWithNameResolutionWarnings(parseEnum(symbol, context));
+			return withNameResolutionWarnings(parseEnum(symbol, context));
 		}
 
 		if (type.isUnion()) {
-			return returnWithNameResolutionWarnings(resolveUnionType(type, typeName, typeNode, context));
+			return withNameResolutionWarnings(resolveUnionType(type, typeName, typeNode, context));
 		}
 
 		if (type.isIntersection()) {
@@ -293,28 +295,28 @@ function resolveTypeUncached(
 			}
 
 			if (memberTypes.length === 1) {
-				return returnWithNameResolutionWarnings(memberTypes[0]);
+				return withNameResolutionWarnings(memberTypes[0]);
 			}
 
 			if (memberTypes.length > 1) {
 				const callSignatures = type.getCallSignatures();
 				if (callSignatures.length >= 1) {
-					return returnWithNameResolutionWarnings(parseFunctionType(type, context)!);
+					return withNameResolutionWarnings(parseFunctionType(type, context)!);
 				}
 
 				const objectType = parseObjectType(type, typeName, context, resolveType);
 				if (objectType) {
-					return returnWithNameResolutionWarnings(
+					return withNameResolutionWarnings(
 						new IntersectionNode(typeName, memberTypes, objectType.properties),
 					);
 				}
 
-				return returnWithNameResolutionWarnings(new IntersectionNode(typeName, memberTypes, []));
+				return withNameResolutionWarnings(new IntersectionNode(typeName, memberTypes, []));
 			}
 		}
 
 		if (checker.isTupleType(type)) {
-			return returnWithNameResolutionWarnings(
+			return withNameResolutionWarnings(
 				new TupleNode(
 					typeName,
 					(type as ts.TupleType).typeArguments?.map((x) => resolveType(x, undefined, context)) ??
@@ -324,26 +326,26 @@ function resolveTypeUncached(
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.String)) {
-			return returnWithNameResolutionWarnings(new IntrinsicNode('string'));
+			return withNameResolutionWarnings(new IntrinsicNode('string'));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.Number)) {
-			return returnWithNameResolutionWarnings(new IntrinsicNode('number'));
+			return withNameResolutionWarnings(new IntrinsicNode('number'));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.BigInt)) {
-			return returnWithNameResolutionWarnings(new IntrinsicNode('bigint'));
+			return withNameResolutionWarnings(new IntrinsicNode('bigint'));
 		}
 
 		if (
 			hasExactFlag(type, ts.TypeFlags.ESSymbol) ||
 			hasExactFlag(type, ts.TypeFlags.UniqueESSymbol)
 		) {
-			return returnWithNameResolutionWarnings(new IntrinsicNode('symbol', typeName));
+			return withNameResolutionWarnings(new IntrinsicNode('symbol', typeName));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.Undefined)) {
-			return returnWithNameResolutionWarnings(new IntrinsicNode('undefined'));
+			return withNameResolutionWarnings(new IntrinsicNode('undefined'));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.Any)) {
@@ -358,18 +360,18 @@ function resolveTypeUncached(
 					// Recursively resolve, passing the memberTypeNode so alias information is preserved
 					unionTypes.push(resolveType(memberType, memberTypeNode, context));
 				}
-				return returnWithNameResolutionWarnings(new UnionNode(typeName, unionTypes));
+				return withNameResolutionWarnings(new UnionNode(typeName, unionTypes));
 			}
-			return returnWithNameResolutionWarnings(new IntrinsicNode('any', typeName));
+			return withNameResolutionWarnings(new IntrinsicNode('any', typeName));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.Unknown)) {
-			return returnWithNameResolutionWarnings(new IntrinsicNode('unknown', typeName));
+			return withNameResolutionWarnings(new IntrinsicNode('unknown', typeName));
 		}
 
 		if (includesCompositeFlag(type, ts.TypeFlags.Literal)) {
 			if (type.isLiteral()) {
-				return returnWithNameResolutionWarnings(
+				return withNameResolutionWarnings(
 					new LiteralNode(
 						type.isStringLiteral() ? `"${type.value}"` : type.value,
 						typeName,
@@ -378,11 +380,11 @@ function resolveTypeUncached(
 				);
 			}
 
-			return returnWithNameResolutionWarnings(new LiteralNode(checker.typeToString(type)));
+			return withNameResolutionWarnings(new LiteralNode(checker.typeToString(type)));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.Null)) {
-			return returnWithNameResolutionWarnings(new IntrinsicNode('null'));
+			return withNameResolutionWarnings(new IntrinsicNode('null'));
 		}
 
 		// TODO: currently types can be either a "function" or an "object" but not both.
@@ -390,7 +392,7 @@ function resolveTypeUncached(
 		// Consider creating a new type that can handle both.
 		const callSignatures = type.getCallSignatures();
 		if (callSignatures.length >= 1) {
-			return returnWithNameResolutionWarnings(parseFunctionType(type, context)!);
+			return withNameResolutionWarnings(parseFunctionType(type, context)!);
 		}
 
 		// Check for class types (have construct signatures)
@@ -398,13 +400,13 @@ function resolveTypeUncached(
 		if (constructSignatures.length >= 1) {
 			const classType = parseClassType(type, context);
 			if (classType) {
-				return returnWithNameResolutionWarnings(classType);
+				return withNameResolutionWarnings(classType);
 			}
 		}
 
 		const objectType = parseObjectType(type, typeName, context, resolveType);
 		if (objectType) {
-			return returnWithNameResolutionWarnings(objectType);
+			return withNameResolutionWarnings(objectType);
 		}
 
 		// Object without properties or object keyword
@@ -412,11 +414,11 @@ function resolveTypeUncached(
 			hasExactFlag(type, ts.TypeFlags.Object) ||
 			(hasExactFlag(type, ts.TypeFlags.NonPrimitive) && checker.typeToString(type) === 'object')
 		) {
-			return returnWithNameResolutionWarnings(new ObjectNode(typeName, [], undefined));
+			return withNameResolutionWarnings(new ObjectNode(typeName, [], undefined));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.Never)) {
-			return returnWithNameResolutionWarnings(new IntrinsicNode('never', typeName));
+			return withNameResolutionWarnings(new IntrinsicNode('never', typeName));
 		}
 
 		if (hasExactFlag(type, ts.TypeFlags.Conditional)) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import ts from 'typescript';
 import { it, expect } from 'vitest';
 import glob from 'fast-glob';
-import { loadConfig, parseFromProgram } from '../src';
+import { loadConfig, parseFromProgram, type ParserWarning } from '../src';
 
 const regenerateOutput = process.env.UPDATE_OUTPUT === 'true';
 
@@ -34,6 +34,8 @@ for (const testCase of testCases) {
 }
 
 const substitutionTypeSource = 'export type X<T> = T extends string ? T : never;';
+const substitutionTypeWithUnsupportedConstraintSource =
+	'export type X<T extends `prefix-${string}`> = T extends string ? T : never;';
 const returnAliasSource = `type WithBase<T> = { [K in keyof T]: T[K] };
 type PropsOf<T> = WithBase<T>;
 
@@ -93,6 +95,32 @@ it('resolves substitution types from representable base types', () => {
 			},
 		],
 	});
+});
+
+it('does not report unsupported warnings when a substitution fallback succeeds', () => {
+	const filePath = '/virtual/substitution-fallback-warning.ts';
+	const warnings: ParserWarning[] = [];
+
+	const moduleDefinition = parseFromProgram(
+		filePath,
+		createInMemoryProgram(filePath, substitutionTypeWithUnsupportedConstraintSource),
+		{
+			onWarning: (warning) => {
+				warnings.push(warning);
+			},
+		},
+	);
+
+	expect(moduleDefinition.exports[0]?.type).toMatchObject({
+		kind: 'union',
+		types: [
+			{
+				kind: 'intrinsic',
+				intrinsic: 'string',
+			},
+		],
+	});
+	expect(warnings).toEqual([]);
 });
 
 it('does not use diagnostic source nodes to change function return type names', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -33,6 +33,7 @@ for (const testCase of testCases) {
 	});
 }
 
+const substitutionTypeSource = 'export type X<T> = T extends string ? T : never;';
 const returnAliasSource = `type WithBase<T> = { [K in keyof T]: T[K] };
 type PropsOf<T> = WithBase<T>;
 
@@ -74,6 +75,25 @@ function createInMemoryProgram(filePath: string, sourceText: string): ts.Program
 
 	return ts.createProgram([filePath], compilerOptions, host);
 }
+
+it('resolves substitution types from representable base types', () => {
+	const filePath = '/virtual/substitution-fallback.ts';
+
+	const moduleDefinition = parseFromProgram(
+		filePath,
+		createInMemoryProgram(filePath, substitutionTypeSource),
+	);
+
+	expect(moduleDefinition.exports[0]?.type).toMatchObject({
+		kind: 'union',
+		types: [
+			{
+				kind: 'typeParameter',
+				name: 'T',
+			},
+		],
+	});
+});
 
 it('does not use diagnostic source nodes to change function return type names', () => {
 	const filePath = '/virtual/return-alias.ts';

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -36,6 +36,8 @@ for (const testCase of testCases) {
 const substitutionTypeSource = 'export type X<T> = T extends string ? T : never;';
 const substitutionTypeWithUnsupportedConstraintSource =
 	'export type X<T extends `prefix-${string}`> = T extends string ? T : never;';
+const substitutionObjectTypeWithUnsupportedConstraintSource =
+	'export type X<T extends `prefix-${string}`> = T extends string ? { v: T } : never;';
 const returnAliasSource = `type WithBase<T> = { [K in keyof T]: T[K] };
 type PropsOf<T> = WithBase<T>;
 
@@ -121,6 +123,55 @@ it('does not report unsupported warnings when a substitution fallback succeeds',
 		],
 	});
 	expect(warnings).toEqual([]);
+});
+
+it('reports conditional name warnings when the resolved type keeps the conditional alias name', () => {
+	const filePath = '/virtual/substitution-fallback-object-warning.ts';
+	const warnings: ParserWarning[] = [];
+
+	const moduleDefinition = parseFromProgram(
+		filePath,
+		createInMemoryProgram(filePath, substitutionObjectTypeWithUnsupportedConstraintSource),
+		{
+			onWarning: (warning) => {
+				warnings.push(warning);
+			},
+		},
+	);
+
+	expect(moduleDefinition.exports[0]?.type).toMatchObject({
+		kind: 'object',
+		typeName: {
+			name: 'X',
+			typeArguments: [
+				{
+					type: {
+						kind: 'typeParameter',
+						name: 'T',
+						constraint: {
+							kind: 'intrinsic',
+							intrinsic: 'any',
+						},
+					},
+				},
+			],
+		},
+		properties: [
+			{
+				name: 'v',
+			},
+		],
+	});
+	expect(warnings).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				code: 'unsupported-type-fallback',
+				typeFlags: ['TemplateLiteral'],
+				typeText: '`prefix-${string}`',
+				sourceText: 'T extends string ? { v: T } : never',
+			}),
+		]),
+	);
 });
 
 it('does not use diagnostic source nodes to change function return type names', () => {

--- a/test/warnings.test.ts
+++ b/test/warnings.test.ts
@@ -13,30 +13,30 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
-const unsupportedTypeSource = 'export type X<T> = T extends string ? T : never;';
-const repeatedUnsupportedTypeSource = `type Weird<T> = T extends string ? T : never;
+const unsupportedTypeSource = 'export type X = `prefix-${string}`;';
+const repeatedUnsupportedTypeSource = `type Weird = \`prefix-\${string}\`;
 
-export interface Props<T> {
-  a: Weird<T>;
-  b: Weird<T>;
+export interface Props {
+  a: Weird;
+  b: Weird;
 }`;
 const implicitClassParameterSource = `export class ClassWarnings {
   methodImplicit<T extends string>(
     value = undefined as \`prefix-\${T}\`,
   ): void {}
 }`;
-const preciseWarningSource = `export function functionReturn<T>():
-  T extends string ? T : never {
+const preciseWarningSource = `export function functionReturn():
+  \`function-\${string}\` {
   return undefined as any;
 }
 
 export class ClassWarnings {
-  methodParam<T>(
-    value: T extends string ? T : never,
+  methodParam(
+    value: \`param-\${string}\`,
   ): void {}
 
-  methodReturn<T>():
-    T extends string ? T : never {
+  methodReturn():
+    \`return-\${string}\` {
     return undefined as any;
   }
 }`;
@@ -70,7 +70,7 @@ function createInMemoryProgram(filePath: string, sourceText: string): ts.Program
 }
 
 function getExpectedUnsupportedTypeWarningMessage(filePath: string): string {
-	return `Type extraction warning: Unable to handle type "T" with flag "Substitution" while resolving "T extends string ? T : never" at "${filePath}:1:20". Using any instead.`;
+	return `Type extraction warning: Unable to handle type "\`prefix-\${string}\`" with flag "TemplateLiteral" at "${filePath}:1:17". Using any instead.`;
 }
 
 it('reports unsupported type fallbacks through onWarning', () => {
@@ -91,15 +91,15 @@ it('reports unsupported type fallbacks through onWarning', () => {
 		code: 'unsupported-type-fallback',
 		filePath,
 		line: 1,
-		column: 20,
+		column: 17,
 		parsedSymbolStack: [filePath, 'X'],
-		typeFlags: ['Substitution'],
-		typeText: 'T',
-		sourceText: 'T extends string ? T : never',
+		typeFlags: ['TemplateLiteral'],
+		typeText: '`prefix-${string}`',
+		sourceText: '`prefix-${string}`',
 	});
 	expect(warnings[0]!.message).toBe(getExpectedUnsupportedTypeWarningMessage(filePath));
 	expect(warnings[0]!.message).toContain('Type extraction warning:');
-	expect(warnings[0]!.message).not.toContain('IncludesInstantiable');
+	expect(warnings[0]!.message).not.toContain('IncludesWildcard');
 });
 
 it('logs unsupported type fallbacks by default', () => {
@@ -131,13 +131,13 @@ it('reports unsupported type fallbacks for repeated cached types', () => {
 		expect.objectContaining({
 			line: 4,
 			column: 6,
-			sourceText: 'Weird<T>',
+			sourceText: 'Weird',
 			parsedSymbolStack: [filePath, 'Props', 'property: a'],
 		}),
 		expect.objectContaining({
 			line: 5,
 			column: 6,
-			sourceText: 'Weird<T>',
+			sourceText: 'Weird',
 			parsedSymbolStack: [filePath, 'Props', 'property: b'],
 		}),
 	]);
@@ -183,19 +183,19 @@ it('reports precise type locations in function and class signatures', () => {
 			expect.objectContaining({
 				line: 2,
 				column: 3,
-				sourceText: 'T extends string ? T : never',
+				sourceText: '`function-${string}`',
 				parsedSymbolStack: [filePath, 'functionReturn'],
 			}),
 			expect.objectContaining({
 				line: 8,
 				column: 12,
-				sourceText: 'T extends string ? T : never',
+				sourceText: '`param-${string}`',
 				parsedSymbolStack: [filePath, 'ClassWarnings', 'parameter: value'],
 			}),
 			expect.objectContaining({
 				line: 12,
 				column: 5,
-				sourceText: 'T extends string ? T : never',
+				sourceText: '`return-${string}`',
 				parsedSymbolStack: [filePath, 'ClassWarnings'],
 			}),
 		]),


### PR DESCRIPTION
## Summary

This PR improves how the extractor handles TypeScript `SubstitutionType` fallbacks.

Instead of immediately falling back to `any`, the resolver now tries to resolve a clean representation of the substitution `baseType`, then the `constraint`. If neither can be represented without triggering another unsupported-type warning, it keeps the existing `any` fallback and warning behavior.

## Why

TypeScript creates substitution types while evaluating conditional, inferred, and mapped types. Some of those internal placeholders have a useful representable base type, so preserving that information avoids avoidable `any` output and warning noise.

## Validation

- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/tsc --project tsconfig.json --noEmit`
- `./node_modules/.bin/eslint src/parsers/typeResolver.ts test/index.test.ts test/warnings.test.ts`
- `./node_modules/.bin/prettier --check README.md src/parser.ts src/parsers/classParser.ts src/parsers/exportParser.ts src/parsers/functionParser.ts src/parsers/propertyParser.ts src/parsers/typeResolver.ts test/index.test.ts test/warnings.test.ts`
- `git diff --check`
