### PR TITLE
[codex] Fix generic alias default argument bounds

### DIFF
--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -49,6 +49,31 @@ const sourceNodeRestorationSource = `export function withReturn():
 }
 
 export type AfterReturn = \`alias-\${string}\`;`;
+const aliasWithExtraResolvedTypeArgumentsSource = `interface Extras<T> {
+  pending: T;
+}
+
+type Result<T> = [T, (next: T) => void, Extras<T>];
+
+interface Options<T, P> {
+  causesLayoutShift: (t: T) => boolean;
+  preload?: (t: T) => P | Promise<P>;
+}
+
+type FixedOptions<P> = Options<string | null, P>;
+
+export function useThing<T, P = void>(
+  initial: T,
+  options: Options<T, P>,
+): Result<T> {
+  return [initial, () => {}, { pending: initial }] as Result<T>;
+}
+
+export function useFixed<P = void>(
+  options: FixedOptions<P>,
+): Result<string | null> {
+  return useThing<string | null, P>(null, options);
+}`;
 
 function getExpectedUnsupportedTypeWarningMessage(filePath: string): string {
 	return `Type extraction warning: Unable to handle type "\`prefix-\${string}\`" with flag "TemplateLiteral" at "${filePath}:1:17". Using any instead.`;
@@ -243,6 +268,60 @@ it('reports precise type locations in function and class signatures', () => {
 		expect(warning.line).not.toBe(1);
 		expect(warning.column).not.toBe(1);
 	}
+});
+
+it('parses generic aliases whose resolved types expose extra type arguments', () => {
+	const filePath = '/virtual/alias-extra-resolved-type-arguments.ts';
+
+	const moduleDefinition = parseFromProgram(
+		filePath,
+		createInMemoryProgram(filePath, aliasWithExtraResolvedTypeArgumentsSource),
+	);
+
+	expect(moduleDefinition.exports).toMatchObject([
+		{
+			name: 'useThing',
+			type: {
+				callSignatures: [
+					{
+						returnValueType: {
+							kind: 'tuple',
+							typeName: {
+								name: 'Result',
+								typeArguments: [
+									expect.objectContaining({ equalToDefault: false }),
+									expect.objectContaining({ equalToDefault: false }),
+									expect.objectContaining({ equalToDefault: false }),
+								],
+							},
+						},
+					},
+				],
+			},
+		},
+		{
+			name: 'useFixed',
+			type: {
+				callSignatures: [
+					{
+						parameters: [
+							{
+								type: {
+									typeName: {
+										name: 'FixedOptions',
+										typeArguments: [
+											expect.objectContaining({ equalToDefault: false }),
+											expect.objectContaining({ equalToDefault: false }),
+										],
+									},
+								},
+							},
+						],
+					},
+				],
+			},
+		},
+	]);
 });
 
 it('reports missing enum declarations through onWarning', () => {

--- a/src/parsers/common.ts
+++ b/src/parsers/common.ts
@@ -346,6 +346,10 @@ function isGenericArgumentsSameAsDefault(
 		return true; // No arguments to compare
 	}
 
+	if (argumentIndex >= typeArguments.length) {
+		return false;
+	}
+
 	if (!targetSymbol?.declarations || targetSymbol.declarations.length === 0) {
 		return false;
 	}
@@ -368,6 +372,9 @@ function isGenericArgumentsSameAsDefault(
 
 	const argumentType = typeArguments[argumentIndex];
 	const typeParameterDeclaration = typeParameters[argumentIndex];
+	if (!typeParameterDeclaration) {
+		return false;
+	}
 
 	if (!typeParameterDeclaration.default) {
 		return false; // Argument provided for a parameter without a default


### PR DESCRIPTION
## Summary

Fixes #143 by making generic default-argument comparison tolerant of aliases whose resolved type exposes more type arguments than the alias declaration owns.

## Root cause

`isGenericArgumentsSameAsDefault` can be called while `getTypeArguments` is iterating the resolved tuple or wrapped generic arguments, but the helper may switch to the authored alias path for default comparison. In that case, the requested argument index can be outside the alias-selected `typeArguments` or declaration `typeParameters`, which previously led to reading `.default` from `undefined`.

## Changes

- Return `false` when the requested generic argument index is out of range for the selected comparison arguments.
- Return `false` when the matching type parameter declaration is missing.
- Add regression coverage for both reported shapes: a generic tuple alias and a generic wrapper alias.

## Validation

- `pnpm exec vitest run src/parser.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck:test-inputs`
- `pnpm prettier`