### PR TITLE
Make Typescript a direct dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,16 @@ pnpm add typescript-api-extractor
 ## Usage
 
 ```typescript
-import ts from 'typescript';
-import { loadConfig, parseFromProgram, type ModuleNode } from 'typescript-api-extractor';
+import {
+	createProgram,
+	loadConfig,
+	parseFromProgram,
+	type ModuleNode,
+} from 'typescript-api-extractor';
 
 // Load TypeScript configuration
 const config = loadConfig('./tsconfig.json');
-const program = ts.createProgram(config.fileNames, config.options);
+const program = createProgram(config.fileNames, config.options);
 
 // Parse all files in the project
 for (const file of config.fileNames) {
@@ -56,15 +60,26 @@ for (const file of config.fileNames) {
 
 ## API Reference
 
+### `createProgram(rootNames: string[], options: CompilerOptions)`
+
+Creates a TypeScript program using the version of TypeScript bundled with
+`typescript-api-extractor`. This is the recommended way to create a program for
+`parseFromProgram`.
+
+- **Parameters:**
+  - `rootNames`: Entry files to include in the program
+  - `options`: TypeScript compiler options
+- **Returns:** `Program`
+
 ### `loadConfig(tsConfigPath: string)`
 
 Loads and parses a TypeScript configuration file.
 
 - **Parameters:**
   - `tsConfigPath`: Path to the `tsconfig.json` file
-- **Returns:** `{ options: ts.CompilerOptions, fileNames: string[] }`
+- **Returns:** `{ options: CompilerOptions, fileNames: string[] }`
 
-### `parseFile(filePath: string, options: ts.CompilerOptions, parserOptions?: ParserOptions)`
+### `parseFile(filePath: string, options: CompilerOptions, parserOptions?: ParserOptions)`
 
 Parses a single TypeScript file and returns the extracted API information.
 
@@ -74,7 +89,7 @@ Parses a single TypeScript file and returns the extracted API information.
   - `parserOptions`: Optional parser configuration
 - **Returns:** `ModuleNode`
 
-### `parseFromProgram(filePath: string, program: ts.Program, parserOptions?: ParserOptions)`
+### `parseFromProgram(filePath: string, program: Program, parserOptions?: ParserOptions)`
 
 Parses a file from an existing TypeScript program for better performance when parsing multiple files.
 

--- a/README.md
+++ b/README.md
@@ -60,16 +60,9 @@ for (const file of config.fileNames) {
 
 ## API Reference
 
-### `createProgram(rootNames: string[], options: CompilerOptions)`
+### `createProgram`
 
-Creates a TypeScript program using the version of TypeScript bundled with
-`typescript-api-extractor`. This is the recommended way to create a program for
-`parseFromProgram`.
-
-- **Parameters:**
-  - `rootNames`: Entry files to include in the program
-  - `options`: TypeScript compiler options
-- **Returns:** `Program`
+Re-export of TypeScript’s `createProgram` from the TypeScript version bundled with `typescript-api-extractor`. It has the same overloads/signature as `typescript.createProgram` and returns a `Program`.
 
 ### `loadConfig(tsConfigPath: string)`
 

--- a/README.md
+++ b/README.md
@@ -343,13 +343,6 @@ type resolution, it should use the active resolver callback from the current
 ## Requirements
 
 - **Node.js**: >= 22
-- **TypeScript**: ^5.8 || ^6.0 (peer dependency)
-
-Make sure you have TypeScript installed in your project:
-
-```bash
-npm install typescript
-```
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 	},
 	"dependencies": {
 		"es-toolkit": "^1.47.0",
-		"typescript": "^6.0.3"
+		"typescript": "^5.8 || ^6.0"
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -36,10 +36,8 @@
 		"prettier": "prettier --write ."
 	},
 	"dependencies": {
-		"es-toolkit": "^1.47.0"
-	},
-	"peerDependencies": {
-		"typescript": "^5.8 || ^6.0"
+		"es-toolkit": "^1.47.0",
+		"typescript": "^6.0.3"
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",
@@ -52,7 +50,6 @@
 		"prettier": "^3.8.3",
 		"rimraf": "^6.1.3",
 		"tsx": "^4.22.3",
-		"typescript": "^6.0.3",
 		"typescript-eslint": "^8.60.0",
 		"vite": "^8.0.14",
 		"vitest": "^4.1.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       es-toolkit:
         specifier: ^1.47.0
         version: 1.47.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -42,9 +45,6 @@ importers:
       tsx:
         specifier: ^4.22.3
         version: 4.22.3
-      typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
       typescript-eslint:
         specifier: ^8.60.0
         version: 8.60.0(eslint@10.4.0)(typescript@6.0.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: ^1.47.0
         version: 1.47.0
       typescript:
-        specifier: ^6.0.3
+        specifier: ^5.8 || ^6.0
         version: 6.0.3
     devDependencies:
       '@eslint/js':

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
 export * from './config';
 export * from './parser';
 export * from './models';
+
+export { createProgram } from 'typescript';
+export type { CompilerOptions, Program } from 'typescript';


### PR DESCRIPTION
Move the `typescript` package from `peerDependencies` to direct `dependencies` so downstream projects can use TSGo.