### PR TITLE
Resolve Extract utility constraints

### DIFF
--- a/src/parsers/typeResolvers/index.ts
+++ b/src/parsers/typeResolvers/index.ts
@@ -9,6 +9,7 @@ import { resolveLiteralType } from './literalTypeResolver';
 import { resolveObjectLikeType } from './objectTypeResolver';
 import {
 	resolveConditionalType,
+	resolveExtractUtilityType,
 	resolveIndexLikeType,
 	resolveTypeParameterType,
 } from './specialTypeResolvers';
@@ -33,6 +34,11 @@ export const typeResolvers: TypeResolver[] = [
 	{ name: 'callable', resolve: resolveCallableType },
 	{ name: 'class', resolve: resolveClassType },
 	{ name: 'object', resolve: resolveObjectLikeType },
+	{
+		name: 'extract-utility',
+		replayNameResolutionWarnings: false,
+		resolve: resolveExtractUtilityType,
+	},
 	{
 		name: 'conditional',
 		replayNameResolutionWarnings: false,

--- a/src/parsers/typeResolvers/specialTypeResolvers.test.ts
+++ b/src/parsers/typeResolvers/specialTypeResolvers.test.ts
@@ -7,6 +7,46 @@ const substitutionTypeWithUnsupportedConstraintSource =
 	'export type X<T extends `prefix-${string}`> = T extends string ? T : never;';
 const substitutionObjectTypeWithUnsupportedConstraintSource =
 	'export type X<T extends `prefix-${string}`> = T extends string ? { v: T } : never;';
+const extractUtilitySource = 'export type StringKeys<T> = Extract<keyof T, string>;';
+const shadowedExtractSource = `type Extract<T, U> = T extends U ? T : number;
+export type ShadowedExtract<T> = Extract<T, string>;`;
+
+it('resolves the built-in Extract utility from its base constraint', () => {
+	const filePath = '/virtual/extract-utility.ts';
+
+	const moduleDefinition = parseFromProgram(
+		filePath,
+		createInMemoryProgram(filePath, extractUtilitySource),
+	);
+
+	expect(moduleDefinition.exports[0]?.type).toMatchObject({
+		kind: 'intrinsic',
+		intrinsic: 'string',
+	});
+});
+
+it('does not treat a local Extract alias as the built-in utility', () => {
+	const filePath = '/virtual/shadowed-extract.ts';
+
+	const moduleDefinition = parseFromProgram(
+		filePath,
+		createInMemoryProgram(filePath, shadowedExtractSource),
+	);
+
+	expect(moduleDefinition.exports[0]?.type).toMatchObject({
+		kind: 'union',
+		types: [
+			{
+				kind: 'typeParameter',
+				name: 'T',
+			},
+			{
+				kind: 'intrinsic',
+				intrinsic: 'number',
+			},
+		],
+	});
+});
 
 it('resolves substitution types from representable base types', () => {
 	const filePath = '/virtual/substitution-fallback.ts';

--- a/src/parsers/typeResolvers/specialTypeResolvers.test.ts
+++ b/src/parsers/typeResolvers/specialTypeResolvers.test.ts
@@ -8,6 +8,8 @@ const substitutionTypeWithUnsupportedConstraintSource =
 const substitutionObjectTypeWithUnsupportedConstraintSource =
 	'export type X<T extends `prefix-${string}`> = T extends string ? { v: T } : never;';
 const extractUtilitySource = 'export type StringKeys<T> = Extract<keyof T, string>;';
+const constrainedExtractUtilitySource =
+	'export type KeepStrings<T extends string> = Extract<T, string>;';
 const shadowedExtractSource = `type Extract<T, U> = T extends U ? T : number;
 export type ShadowedExtract<T> = Extract<T, string>;`;
 
@@ -22,6 +24,32 @@ it('resolves the built-in Extract utility from its base constraint', () => {
 	expect(moduleDefinition.exports[0]?.type).toMatchObject({
 		kind: 'intrinsic',
 		intrinsic: 'string',
+	});
+});
+
+it('keeps the type parameter when Extract narrows a constrained type parameter', () => {
+	const filePath = '/virtual/constrained-extract-utility.ts';
+
+	// `Extract<T, string>` with `T extends string` is exactly `T`, so it must
+	// resolve like the equivalent `T extends string ? T : never` conditional
+	// instead of collapsing to the `string` base constraint.
+	const moduleDefinition = parseFromProgram(
+		filePath,
+		createInMemoryProgram(filePath, constrainedExtractUtilitySource),
+	);
+
+	expect(moduleDefinition.exports[0]?.type).toMatchObject({
+		kind: 'union',
+		types: [
+			{
+				kind: 'typeParameter',
+				name: 'T',
+				constraint: {
+					kind: 'intrinsic',
+					intrinsic: 'string',
+				},
+			},
+		],
 	});
 });
 

--- a/src/parsers/typeResolvers/specialTypeResolvers.ts
+++ b/src/parsers/typeResolvers/specialTypeResolvers.ts
@@ -60,6 +60,43 @@ export function resolveTypeParameterType(
 }
 
 /**
+ * Resolves TypeScript's built-in `Extract<T, U>` utility through the base
+ * constraint computed by the checker. For unresolved inputs, TypeScript exposes
+ * the true branch as a narrowing intersection (for example,
+ * `string & keyof T`), while the base constraint is the representable result
+ * bound (`string` in that example).
+ */
+export function resolveExtractUtilityType(
+	{ type }: TypeResolutionRequest,
+	session: TypeResolutionSession,
+): AnyType | undefined {
+	if (!hasExactFlag(type, ts.TypeFlags.Conditional)) {
+		return undefined;
+	}
+
+	const conditionalType = type as ts.ConditionalType;
+	if (!isBuiltInExtractSymbol(conditionalType.root.aliasSymbol)) {
+		return undefined;
+	}
+
+	const baseConstraint = session.context.checker.getBaseConstraintOfType(type);
+	if (!baseConstraint || baseConstraint === type) {
+		return undefined;
+	}
+
+	return session.resolve(baseConstraint, undefined);
+}
+
+function isBuiltInExtractSymbol(symbol: ts.Symbol | undefined): boolean {
+	return (
+		symbol?.getName() === 'Extract' &&
+		symbol.declarations?.some((declaration) =>
+			/[\\/]typescript[\\/]lib[\\/]lib\.[^\\/]+\.d\.ts$/.test(declaration.getSourceFile().fileName),
+		) === true
+	);
+}
+
+/**
  * Resolves a conditional type `T extends X ? A : B`. Since the parser cannot
  * evaluate the condition in the general case, it emits both resolved branches as
  * a union (or the single branch TypeScript managed to resolve).

--- a/src/parsers/typeResolvers/specialTypeResolvers.ts
+++ b/src/parsers/typeResolvers/specialTypeResolvers.ts
@@ -60,11 +60,19 @@ export function resolveTypeParameterType(
 }
 
 /**
- * Resolves TypeScript's built-in `Extract<T, U>` utility through the base
- * constraint computed by the checker. For unresolved inputs, TypeScript exposes
+ * Resolves TypeScript's built-in `Extract<T, U>` utility over an index-like
+ * check type (`Extract<keyof T, string>`, `Extract<T[K], string>`) through the
+ * base constraint computed by the checker. For those inputs, TypeScript exposes
  * the true branch as a narrowing intersection (for example,
  * `string & keyof T`), while the base constraint is the representable result
  * bound (`string` in that example).
+ *
+ * The shortcut is deliberately limited to index-like check types, which
+ * `resolveIndexLikeType` already collapses to their base constraint, so the
+ * genericity lost here would have been lost anyway. `Extract` over a naked type
+ * parameter is exactly that parameter (`Extract<T, string>` with
+ * `T extends string` is `T`), and the conditional fallback keeps it as a
+ * TypeParameterNode, so those must not take this path.
  */
 export function resolveExtractUtilityType(
 	{ type }: TypeResolutionRequest,
@@ -75,7 +83,10 @@ export function resolveExtractUtilityType(
 	}
 
 	const conditionalType = type as ts.ConditionalType;
-	if (!isBuiltInExtractSymbol(conditionalType.root.aliasSymbol)) {
+	if (
+		!isBuiltInExtractSymbol(conditionalType.root.aliasSymbol) ||
+		!isIndexLikeType(conditionalType.checkType)
+	) {
 		return undefined;
 	}
 
@@ -85,6 +96,10 @@ export function resolveExtractUtilityType(
 	}
 
 	return session.resolve(baseConstraint, undefined);
+}
+
+function isIndexLikeType(type: ts.Type): boolean {
+	return hasExactFlag(type, ts.TypeFlags.Index) || hasExactFlag(type, ts.TypeFlags.IndexedAccess);
 }
 
 function isBuiltInExtractSymbol(symbol: ts.Symbol | undefined): boolean {
@@ -134,7 +149,7 @@ export function resolveIndexLikeType(
 	{ type, typeName }: TypeResolutionRequest,
 	session: TypeResolutionSession,
 ): AnyType | undefined {
-	if (!hasExactFlag(type, ts.TypeFlags.Index) && !hasExactFlag(type, ts.TypeFlags.IndexedAccess)) {
+	if (!isIndexLikeType(type)) {
 		return undefined;
 	}
 

--- a/test/fixtures/type-extract-utility-resolution/input.ts
+++ b/test/fixtures/type-extract-utility-resolution/input.ts
@@ -1,0 +1,1 @@
+export type StringKeys<T> = Extract<keyof T, string>;

--- a/test/fixtures/type-extract-utility-resolution/input.ts
+++ b/test/fixtures/type-extract-utility-resolution/input.ts
@@ -1,1 +1,5 @@
 export type StringKeys<T> = Extract<keyof T, string>;
+
+export type StringValues<T, K extends keyof T> = Extract<T[K], string>;
+
+export type KeepStrings<T extends string> = Extract<T, string>;

--- a/test/fixtures/type-extract-utility-resolution/output.json
+++ b/test/fixtures/type-extract-utility-resolution/output.json
@@ -1,0 +1,12 @@
+{
+	"name": "test/fixtures/type-extract-utility-resolution/input",
+	"exports": [
+		{
+			"name": "StringKeys",
+			"type": {
+				"kind": "intrinsic",
+				"intrinsic": "string"
+			}
+		}
+	]
+}

--- a/test/fixtures/type-extract-utility-resolution/output.json
+++ b/test/fixtures/type-extract-utility-resolution/output.json
@@ -7,6 +7,29 @@
 				"kind": "intrinsic",
 				"intrinsic": "string"
 			}
+		},
+		{
+			"name": "StringValues",
+			"type": {
+				"kind": "intrinsic",
+				"intrinsic": "string"
+			}
+		},
+		{
+			"name": "KeepStrings",
+			"type": {
+				"kind": "union",
+				"types": [
+					{
+						"name": "T",
+						"constraint": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"kind": "typeParameter"
+					}
+				]
+			}
 		}
 	]
 }


### PR DESCRIPTION
## Summary

- add a narrow resolver for TypeScript's built-in `Extract<T, U>` utility
- resolve representable `Extract` results through the compiler-provided base constraint
- preserve the existing conditional fallback for locally shadowed `Extract` aliases
- add focused and fixture-based regression coverage

## Root cause

Unresolved `Extract<keyof T, string>` types reach the generic conditional resolver. TypeScript exposes the true branch as `string & keyof T`, after which the index-like fallback expands `keyof T` to `string | number | symbol`. The extractor therefore emitted `string & (string | number | symbol)` instead of the compiler's representable base constraint, `string`.

The new resolver runs before the broad conditional fallback, verifies that the conditional root is the `Extract` declaration from TypeScript's standard library, and resolves its base constraint when one is available. Other conditional types retain their current behavior.

## User impact

API output for patterns such as `Extract<keyof T, string>` is now the expected `string`, avoiding wider and confusing generated documentation types.

## Verification

- `pnpm build`
- `pnpm typecheck`
- `pnpm typecheck:test-inputs`
- `pnpm lint`
- `pnpm exec vitest run` — 15 test files, 151 tests passed

Closes #189