### PR TITLE
Report large prop lists and union-shaped components

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ interface ParserOptions {
 		name: string;
 		propertyCount: number;
 		depth: number;
+		propertyDepth: number;
 	}) => boolean | undefined;
 	includeExternalTypes?: boolean;
 	onWarning?: (warning: ParserWarning) => void;
@@ -138,6 +139,18 @@ interface MissingDefaultExportSymbolWarning extends ParserWarningBase {
 	sourceText: string;
 }
 ```
+
+`shouldResolveObject` decides whether an object's shape is expanded or reduced to
+a bare object. Returning `undefined` falls back to
+`(propertyDepth === 0 || propertyCount <= 50) && depth <= 10`.
+
+`depth` counts every type on the resolution stack, while `propertyDepth` counts
+only the property (and index signature) values traversed to reach the object. A
+`propertyDepth` of `0` means the object is the export's own type or something
+reached from it through composition alone - aliases, unions, intersections, and
+the parameter and return types of its call signatures. The default rule applies
+the property-count limit only above that, so a large component prop list is
+reported in full while its individual props stay bounded.
 
 When `onWarning` is omitted, recoverable parser warnings are printed with
 `console.warn`. Provide `onWarning` to collect or format them yourself.
@@ -259,7 +272,9 @@ substructures that are reused across multiple type classes.
   export nodes are built. Today it runs the React component transform from
   `componentParser.ts`.
 - `src/parsers/componentParser.ts` contains React component-specific extraction
-  and should remain a transform policy rather than a generic export parser.
+  and should remain a transform policy rather than a generic export parser. It
+  recognizes both a single function type and a union of them, so a polymorphic
+  component whose arms differ per prop form still reports one merged prop list.
 - `src/parsers/typeResolver.ts` is the public type-resolution facade used by the
   rest of the parser. It should stay small; the resolver implementation lives in
   the session and resolver modules.

--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ substructures that are reused across multiple type classes.
   and should remain a transform policy rather than a generic export parser. It
   recognizes both a single function type and a union of them, so a polymorphic
   component whose arms differ per prop form still reports one merged prop list.
+  Return types are matched by name rather than by resolved node kind, so
+  `includeExternalTypes` changes how much detail the output carries without
+  changing what counts as a component.
 - `src/parsers/typeResolver.ts` is the public type-resolution facade used by the
   rest of the parser. It should stay small; the resolver implementation lives in
   the session and resolver modules.

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -59,6 +59,7 @@ function createParserContext(
 		parsedSymbolStack,
 		sourceNodeStack,
 		program,
+		propertyDepth: 0,
 		resolvedTypeCache: new Map<string, AnyType>(),
 		...getParserOptions(parserOptions),
 		runWithSymbolScope: (symbolName, callback) =>
@@ -69,6 +70,15 @@ function createParserContext(
 			}
 
 			return runWithStackEntryScope(sourceNodeStack, sourceNode, callback);
+		},
+		runWithPropertyValueScope: (callback) => {
+			context.propertyDepth += 1;
+
+			try {
+				return callback();
+			} finally {
+				context.propertyDepth -= 1;
+			}
 		},
 		runWithTypeParameterSubstitutionScope: (typeParameterSubstitutions, callback) => {
 			const previousTypeParameterSubstitutions = context.typeParameterSubstitutions;
@@ -119,7 +129,13 @@ function getParserOptions(parserOptions: ParserOptions): ResolvedParserOptions {
 			}
 		}
 
-		return data.propertyCount <= 50 && data.depth <= 10;
+		// The property-count limit guards against expanding huge shapes that a
+		// consumer never asked about. It must not apply at `propertyDepth === 0`:
+		// that is the export's own type and everything reached from it through
+		// type composition alone, so capping there erases the very shape being
+		// documented (e.g. a component's whole prop list) instead of trimming a
+		// nested detail. The depth limit still bounds recursion everywhere.
+		return (data.propertyDepth === 0 || data.propertyCount <= 50) && data.depth <= 10;
 	};
 
 	return {
@@ -136,7 +152,7 @@ function getParserOptions(parserOptions: ParserOptions): ResolvedParserOptions {
 
 interface ResolvedParserOptions {
 	shouldInclude: (data: { name: string; depth: number }) => boolean;
-	shouldResolveObject: (data: { name: string; propertyCount: number; depth: number }) => boolean;
+	shouldResolveObject: (data: ShouldResolveObjectData) => boolean;
 	includeExternalTypes: boolean;
 	onWarning: (warning: ParserWarning) => void;
 }
@@ -151,12 +167,39 @@ export interface ParserContext extends ResolvedParserOptions {
 	program: ts.Program;
 	typeParameterSubstitutions?: Map<ts.Symbol, ts.Type>;
 	/**
+	 * How many property (or index signature) values were traversed to reach the
+	 * type currently being resolved. See `ShouldResolveObjectData.propertyDepth`.
+	 */
+	propertyDepth: number;
+	/**
 	 * Cache for resolved types to avoid resolving the same type multiple times.
-	 * The key encodes both the type ID and the current stack depth, because
-	 * depth-dependent options (`shouldResolveObject`, `shouldInclude`) can
-	 * produce different results for the same type at different depths.
+	 * The key encodes the type ID together with the current stack and property
+	 * depths, because depth-dependent options (`shouldResolveObject`,
+	 * `shouldInclude`) can produce different results for the same type at
+	 * different depths.
 	 */
 	resolvedTypeCache: Map<string, AnyType>;
+}
+
+/**
+ * Describes the object whose shape is about to be resolved.
+ */
+export interface ShouldResolveObjectData {
+	/** Name of the object's type, or an empty string for anonymous shapes. */
+	name: string;
+	/** Number of properties the object would contribute to the output. */
+	propertyCount: number;
+	/** Depth of the type-resolution stack, counting every intermediate type. */
+	depth: number;
+	/**
+	 * How many property (or index signature) values were traversed to reach this
+	 * object. It is 0 for the export's own type and for everything reached from
+	 * it through type composition alone - aliases, unions, intersections, and the
+	 * parameter and return types of its call signatures. In other words, a
+	 * `propertyDepth` of 0 marks the shapes the caller directly asked about,
+	 * while anything above 0 is a nested detail of one of them.
+	 */
+	propertyDepth: number;
 }
 
 /**
@@ -171,13 +214,9 @@ export interface ParserOptions {
 	 * Called before the shape of an object is resolved
 	 * @return true to resolve the shape of the object, false to just use a object, or undefined to
 	 * use the default behaviour
-	 * @default propertyCount <= 50 && depth <= 10
+	 * @default (propertyDepth === 0 || propertyCount <= 50) && depth <= 10
 	 */
-	shouldResolveObject?: (data: {
-		name: string;
-		propertyCount: number;
-		depth: number;
-	}) => boolean | undefined;
+	shouldResolveObject?: (data: ShouldResolveObjectData) => boolean | undefined;
 	/**
 	 * Control if external types and members should be included in the output.
 	 * @default false

--- a/src/parserContext.ts
+++ b/src/parserContext.ts
@@ -21,6 +21,13 @@ export interface ScopedParserContext extends ParserContext {
 	 */
 	runWithSourceNodeScope<T>(sourceNode: ts.Node | undefined, callback: () => T): T;
 	/**
+	 * Runs resolver work one property level deeper, for the value type of a
+	 * property or index signature. `shouldResolveObject` reads the resulting
+	 * `propertyDepth` to tell the shape a caller asked about from the nested
+	 * details of that shape.
+	 */
+	runWithPropertyValueScope<T>(callback: () => T): T;
+	/**
 	 * Runs resolver work in a temporary type-parameter substitution scope for
 	 * mapped/instantiated type expansion. The previous substitution map is
 	 * always restored.

--- a/src/parsers/componentParser.test.ts
+++ b/src/parsers/componentParser.test.ts
@@ -1,0 +1,46 @@
+import path from 'node:path';
+import ts from 'typescript';
+import { expect, it } from 'vitest';
+import { loadConfig, parseFromProgram } from '../index';
+
+const returnTypesInput = path.resolve(
+	__dirname,
+	'../../test/fixtures/react-component-return-types/input.tsx',
+);
+const program = ts.createProgram(
+	[returnTypesInput],
+	loadConfig(path.resolve(__dirname, '../../test/tsconfig.json')).options,
+);
+
+function classifyExports(includeExternalTypes: boolean): Record<string, string> {
+	const moduleDefinition = parseFromProgram(returnTypesInput, program, {
+		includeExternalTypes,
+		onWarning: () => {},
+	});
+
+	return Object.fromEntries(
+		moduleDefinition.exports.map((exportNode) => [exportNode.name, exportNode.type.kind]),
+	);
+}
+
+const expectedClassification = {
+	NamespacedElement: 'component',
+	BareElement: 'component',
+	GenericElement: 'component',
+	BareNode: 'component',
+	NullableElement: 'component',
+	InferredElement: 'component',
+	LocalElementType: 'function',
+	DomElementType: 'function',
+};
+
+it('recognizes React return types without mistaking lookalikes for components', () => {
+	expect(classifyExports(false)).toEqual(expectedClassification);
+});
+
+// `includeExternalTypes` decides whether React's types are summarized as
+// external references or expanded into objects and unions. That is a choice
+// about output detail, so it must not change what counts as a component.
+it('detects the same components whether external types are summarized or expanded', () => {
+	expect(classifyExports(true)).toEqual(expectedClassification);
+});

--- a/src/parsers/componentParser.ts
+++ b/src/parsers/componentParser.ts
@@ -9,52 +9,125 @@ import {
 	ExternalTypeNode,
 	UnionNode,
 	IntersectionNode,
+	type AnyType,
 } from '../models';
 import { TypeName } from '../models/typeName';
 import { ParserContext } from '../parser';
 
 const componentReturnTypes = [/Element/, /ReactNode/, /ReactElement(<.*>)?/];
 
-type FunctionExportNode = ExportNode & { type: FunctionNode };
+type ComponentExportNode = ExportNode & { type: FunctionNode | UnionNode };
 
 function isReactReturnType(type: ExternalTypeNode) {
 	return componentReturnTypes.some((regex) => regex.test(type.typeName?.name ?? ''));
 }
 
 /**
- * Rewrites a function export into a ComponentNode when it looks like a React
- * component (see `isComponentExport`), squashing the props parameter of every
- * call signature into one merged prop list. Non-component exports pass through.
+ * Rewrites an export into a ComponentNode when it looks like a React component
+ * (see `isComponentExport`), squashing the props parameter of every call
+ * signature into one merged prop list. Non-component exports pass through.
  */
 export function transformComponentExport(node: ExportNode, context: ParserContext): ExportNode {
-	if (!isComponentExport(node)) {
+	const componentFunctions = getComponentFunctions(node);
+	if (!componentFunctions) {
 		return node;
 	}
 
-	return node.withType(createComponentNode(node.type, context));
+	return node.withType(createComponentNode(node.type, componentFunctions, context));
 }
 
 /**
- * Heuristic for whether an export is a React component: a function whose name is
- * capitalized (or `default`) and whose return type looks like a React node.
+ * Heuristic for whether an export is a React component: its name is capitalized
+ * (or `default`) and its type is a function returning something React-node-like,
+ * or a union of such functions.
  */
-export function isComponentExport(node: ExportNode): node is FunctionExportNode {
-	return (
-		node.type instanceof FunctionNode &&
-		isComponentExportName(node.name) &&
-		hasReactNodeLikeReturnType(node.type)
-	);
+export function isComponentExport(node: ExportNode): node is ComponentExportNode {
+	return getComponentFunctions(node) !== undefined;
 }
 
 function isComponentExportName(name: string): boolean {
 	return /^[A-Z]/.test(name) || name === 'default';
 }
 
-function createComponentNode(type: FunctionNode, context: ParserContext): ComponentNode {
+/**
+ * Collects the function nodes holding a component's call signatures, or returns
+ * undefined when the export is not a component.
+ */
+function getComponentFunctions(node: ExportNode): FunctionNode[] | undefined {
+	if (!isComponentExportName(node.name)) {
+		return undefined;
+	}
+
+	return collectComponentFunctions(node.type);
+}
+
+function collectComponentFunctions(type: AnyType): FunctionNode[] | undefined {
+	if (type instanceof FunctionNode) {
+		return hasReactNodeLikeReturnType(type) ? [type] : undefined;
+	}
+
+	// A component can surface as a union of function types rather than a single
+	// one - for instance when a polymorphic component declares a separate arm per
+	// `render` prop form. Treat it as one component only when every arm is itself
+	// component-like, so unions that merely happen to contain a component (say
+	// `Button | undefined`) keep their union shape.
+	if (type instanceof UnionNode) {
+		const componentFunctions: FunctionNode[] = [];
+		for (const member of type.types) {
+			const memberFunctions = collectComponentFunctions(member);
+			if (!memberFunctions) {
+				return undefined;
+			}
+
+			componentFunctions.push(...memberFunctions);
+		}
+
+		return componentFunctions.length > 0 ? componentFunctions : undefined;
+	}
+
+	return undefined;
+}
+
+function createComponentNode(
+	type: AnyType,
+	componentFunctions: FunctionNode[],
+	context: ParserContext,
+): ComponentNode {
+	// Arms of a union describe the same component under different prop forms, so
+	// their signatures squash together into one prop list. Props missing from some
+	// arms come out optional, which is what `squashComponentProps` already does
+	// for overloads.
+	const callSignatures = componentFunctions.flatMap((fn) => fn.callSignatures);
+
 	return new ComponentNode(
-		cloneTypeName(type.typeName),
-		squashComponentProps(type.callSignatures, context),
+		cloneTypeName(getComponentTypeName(type, componentFunctions)),
+		squashComponentProps(callSignatures, context),
 	);
+}
+
+/**
+ * An aliased union names the component directly. An unaliased one only gets a
+ * name when every arm agrees on it, because no single arm's name describes the
+ * merged result.
+ */
+function getComponentTypeName(
+	type: AnyType,
+	componentFunctions: FunctionNode[],
+): TypeName | undefined {
+	const ownTypeName = 'typeName' in type ? type.typeName : undefined;
+	if (ownTypeName) {
+		return ownTypeName;
+	}
+
+	const [firstFunction, ...remainingFunctions] = componentFunctions;
+	const firstTypeName = firstFunction?.typeName;
+	if (!firstTypeName) {
+		return undefined;
+	}
+
+	return remainingFunctions.every((fn) => fn.typeName?.toString() === firstTypeName.toString())
+		? firstTypeName
+		: undefined;
 }
 
 function cloneTypeName(typeName: TypeName | undefined): TypeName | undefined {

--- a/src/parsers/componentParser.ts
+++ b/src/parsers/componentParser.ts
@@ -6,7 +6,6 @@ import {
 	IntrinsicNode,
 	PropertyNode,
 	ObjectNode,
-	ExternalTypeNode,
 	UnionNode,
 	IntersectionNode,
 	type AnyType,
@@ -14,12 +13,26 @@ import {
 import { TypeName } from '../models/typeName';
 import { ParserContext } from '../parser';
 
-const componentReturnTypes = [/Element/, /ReactNode/, /ReactElement(<.*>)?/];
+// The names React uses for what a component renders. Detection goes by name
+// rather than by node kind: the same return type surfaces as an ExternalTypeNode
+// when external types are summarized and as an object or union when
+// `includeExternalTypes` expands them, so the kind says nothing about whether
+// the type is React's. Names match exactly, which keeps unrelated types that
+// merely end in `Element` - a local `ListElement`, or the DOM's `HTMLElement` -
+// from turning every function returning one into a component.
+const componentReturnTypeNames = new Set(['Element', 'ReactElement', 'ReactNode']);
 
 type ComponentExportNode = ExportNode & { type: FunctionNode | UnionNode };
 
-function isReactReturnType(type: ExternalTypeNode) {
-	return componentReturnTypes.some((regex) => regex.test(type.typeName?.name ?? ''));
+function isReactReturnType(type: AnyType): boolean {
+	const typeName = 'typeName' in type ? type.typeName : undefined;
+	if (typeName && componentReturnTypeNames.has(typeName.name)) {
+		return true;
+	}
+
+	// Return types like `JSX.Element | null` describe a component through one of
+	// their members.
+	return type instanceof UnionNode && type.types.some(isReactReturnType);
 }
 
 /**
@@ -139,15 +152,7 @@ function cloneTypeName(typeName: TypeName | undefined): TypeName | undefined {
 }
 
 function hasReactNodeLikeReturnType(type: FunctionNode) {
-	return type.callSignatures.some(
-		(signature) =>
-			(signature.returnValueType instanceof ExternalTypeNode &&
-				isReactReturnType(signature.returnValueType)) ||
-			(signature.returnValueType instanceof UnionNode &&
-				signature.returnValueType.types.some(
-					(type) => type instanceof ExternalTypeNode && isReactReturnType(type),
-				)),
-	);
+	return type.callSignatures.some((signature) => isReactReturnType(signature.returnValueType));
 }
 
 function squashComponentProps(callSignatures: CallSignature[], context: ParserContext) {

--- a/src/parsers/componentParser.ts
+++ b/src/parsers/componentParser.ts
@@ -217,6 +217,16 @@ function squashComponentProps(callSignatures: CallSignature[], context: ParserCo
 		usedPropsPerSignature.push(usedProps);
 	});
 
+	// A signature that takes no props at all uses none of the props gathered above, so it
+	// contributes an empty set. It is dropped from `propsFromCallSignatures` (there is no
+	// props parameter to read a shape from), and without this the props of the remaining
+	// signatures would stay required even though one form of the component rejects them.
+	for (const signature of callSignatures) {
+		if (signature.parameters.length === 0) {
+			usedPropsPerSignature.push(new Set());
+		}
+	}
+
 	// If a prop is used in some signatures, but not in others, we need to mark it as optional.
 	return [...props.entries()].map(([name, property]) => {
 		const onlyUsedInSomeSignatures = usedPropsPerSignature.some((props) => !props.has(name));

--- a/src/parsers/exportDescriptors.test.ts
+++ b/src/parsers/exportDescriptors.test.ts
@@ -20,6 +20,7 @@ function createDescriptorContext(filePath: string, program: ts.Program): ScopedP
 		parsedSymbolStack,
 		sourceNodeStack,
 		program,
+		propertyDepth: 0,
 		resolvedTypeCache: new Map(),
 		shouldInclude: () => true,
 		shouldResolveObject: () => true,
@@ -45,6 +46,7 @@ function createDescriptorContext(filePath: string, program: ts.Program): ScopedP
 				}
 			}
 		},
+		runWithPropertyValueScope: <T>(callback: () => T): T => callback(),
 		runWithTypeParameterSubstitutionScope: <T>(
 			_substitutions: Map<ts.Symbol, ts.Type>,
 			callback: () => T,

--- a/src/parsers/exportTransforms.test.ts
+++ b/src/parsers/exportTransforms.test.ts
@@ -116,6 +116,22 @@ it('merges the props of every union member into one component', () => {
 	expect(componentNode.typeName).toBeUndefined();
 });
 
+it('marks props as optional when a union member accepts no props', () => {
+	const componentUnion = new UnionNode(undefined, [
+		createFunctionNode(undefined, 'ToolbarStandalone', []),
+		createFunctionNode(undefined, 'ToolbarWithProps', ['id']),
+	]);
+	const exportNode = new ExportNode('Toolbar', componentUnion, undefined);
+
+	const componentNode = applyExportTransforms([exportNode], parserContext)[0]!
+		.type as ComponentNode;
+
+	expect(componentNode).toBeInstanceOf(ComponentNode);
+	expect(componentNode.props.map((prop) => prop.name)).toEqual(['id']);
+	// The parameterless member accepts no props, so `id` only applies to the other form.
+	expect(componentNode.props[0]!.optional).toBe(true);
+});
+
 it('keeps the shared type name when every union member agrees on it', () => {
 	const componentUnion = new UnionNode(undefined, [
 		createFunctionNode(undefined, 'Toolbar', ['children']),

--- a/src/parsers/exportTransforms.test.ts
+++ b/src/parsers/exportTransforms.test.ts
@@ -7,6 +7,9 @@ import {
 	ExternalTypeNode,
 	FunctionNode,
 	IntrinsicNode,
+	ObjectNode,
+	Parameter,
+	PropertyNode,
 	TypeName,
 	UnionNode,
 	type AnyType,
@@ -22,8 +25,26 @@ const parserContext = {
 
 function createFunctionNode(
 	returnValueType: AnyType = new ExternalTypeNode(new TypeName('ReactElement')),
+	typeName = 'Button',
+	propNames: string[] = [],
 ) {
-	return new FunctionNode(new TypeName('Button'), [new CallSignature([], returnValueType)]);
+	const props = propNames.map(
+		(propName) => new PropertyNode(propName, new IntrinsicNode('string'), undefined, false),
+	);
+	const parameters =
+		props.length > 0
+			? [
+					new Parameter(
+						new ObjectNode(undefined, props, undefined),
+						'props',
+						undefined,
+						false,
+						undefined,
+					),
+				]
+			: [];
+
+	return new FunctionNode(new TypeName(typeName), [new CallSignature(parameters, returnValueType)]);
 }
 
 it('classifies component exports separately from export transformation', () => {
@@ -49,6 +70,63 @@ it('classifies component exports separately from export transformation', () => {
 			new ExportNode('Button', createFunctionNode(new IntrinsicNode('string')), undefined),
 		),
 	).toBe(false);
+});
+
+it('classifies a union of component-like functions as a component export', () => {
+	const componentUnion = new UnionNode(undefined, [
+		createFunctionNode(undefined, 'ToolbarRoot', ['children']),
+		createFunctionNode(undefined, 'ToolbarWithRender', ['render']),
+	]);
+
+	expect(isComponentExport(new ExportNode('Toolbar', componentUnion, undefined))).toBe(true);
+});
+
+it('keeps unions with a non-component member out of the component classification', () => {
+	const partialUnion = new UnionNode(undefined, [
+		createFunctionNode(undefined, 'ToolbarRoot', ['children']),
+		new IntrinsicNode('undefined'),
+	]);
+
+	expect(isComponentExport(new ExportNode('Toolbar', partialUnion, undefined))).toBe(false);
+});
+
+it('merges the props of every union member into one component', () => {
+	const componentUnion = new UnionNode(undefined, [
+		createFunctionNode(undefined, 'ToolbarRoot', ['children', 'className']),
+		createFunctionNode(undefined, 'ToolbarWithRender', ['render', 'className']),
+	]);
+	const exportNode = new ExportNode('Toolbar', componentUnion, undefined);
+
+	const componentNode = applyExportTransforms([exportNode], parserContext)[0]!
+		.type as ComponentNode;
+
+	expect(componentNode).toBeInstanceOf(ComponentNode);
+	expect(componentNode.props.map((prop) => prop.name).sort()).toEqual([
+		'children',
+		'className',
+		'render',
+	]);
+	// `className` comes from both members, so it stays required; the other two are
+	// specific to one member and only apply to that form of the component.
+	expect(componentNode.props.filter((prop) => prop.optional).map((prop) => prop.name)).toEqual([
+		'children',
+		'render',
+	]);
+	// No single member name describes the merged component.
+	expect(componentNode.typeName).toBeUndefined();
+});
+
+it('keeps the shared type name when every union member agrees on it', () => {
+	const componentUnion = new UnionNode(undefined, [
+		createFunctionNode(undefined, 'Toolbar', ['children']),
+		createFunctionNode(undefined, 'Toolbar', ['render']),
+	]);
+	const exportNode = new ExportNode('Toolbar', componentUnion, undefined);
+
+	const componentNode = applyExportTransforms([exportNode], parserContext)[0]!
+		.type as ComponentNode;
+
+	expect(componentNode.typeName?.name).toBe('Toolbar');
 });
 
 it('applies component transforms without losing export metadata', () => {

--- a/src/parsers/typeResolutionSession.ts
+++ b/src/parsers/typeResolutionSession.ts
@@ -38,13 +38,16 @@ export class TypeResolutionSession implements TypeResolutionSessionContract {
 	};
 
 	resolve(type: ts.Type, typeNode: ts.TypeNode | undefined): AnyType {
-		const { resolvedTypeCache, typeStack } = this.context;
+		const { resolvedTypeCache, typeStack, propertyDepth } = this.context;
 
 		const typeId = getTypeId(type);
 
-		// Build a cache key that incorporates both the type identity and the current
-		// stack depth, because shouldResolveObject / shouldInclude are depth-sensitive.
-		const cacheKey = typeId !== undefined ? `${typeId}@${typeStack.length}` : undefined;
+		// Build a cache key that incorporates the type identity and both depth
+		// counters, because shouldResolveObject / shouldInclude are depth-sensitive:
+		// the same type resolves to a different shape as an export's own type than
+		// it does nested under someone's property.
+		const cacheKey =
+			typeId !== undefined ? `${typeId}@${typeStack.length}:${propertyDepth}` : undefined;
 
 		if (
 			cacheKey !== undefined &&

--- a/src/parsers/typeResolvers/objectTypeResolver.test.ts
+++ b/src/parsers/typeResolvers/objectTypeResolver.test.ts
@@ -5,8 +5,12 @@ import { loadConfig, parseFromProgram } from '../../index';
 
 const fixturesDir = path.resolve(__dirname, '../../../test/fixtures');
 const mappedAliasFiniteKeyInput = path.join(fixturesDir, 'mapped-alias-finite-key/input.ts');
+const propertyCountLimitInput = path.join(
+	fixturesDir,
+	'object-property-count-limit-scope/input.tsx',
+);
 const program = ts.createProgram(
-	[mappedAliasFiniteKeyInput],
+	[mappedAliasFiniteKeyInput, propertyCountLimitInput],
 	loadConfig(path.resolve(__dirname, '../../../test/tsconfig.json')).options,
 );
 
@@ -22,4 +26,40 @@ it('applies shouldInclude to finite mapped properties', async () => {
 	expect(
 		specializedExport.type.properties.map((property: { name: string }) => property.name),
 	).toEqual(['a']);
+});
+
+it('reports the property depth an object was reached at', () => {
+	const observedDepths = new Map<string, Set<number>>();
+	parseFromProgram(propertyCountLimitInput, program, {
+		shouldResolveObject: ({ name, propertyDepth }) => {
+			const depths = observedDepths.get(name) ?? new Set<number>();
+			depths.add(propertyDepth);
+			observedDepths.set(name, depths);
+			return undefined;
+		},
+	});
+
+	// Reached through composition from the export, so it is part of the shape the
+	// caller asked about.
+	expect([...(observedDepths.get('ManyProps') ?? [])]).toEqual([0]);
+	// Reached through the `nested` property, so it is a detail of that shape.
+	expect([...(observedDepths.get('ManyNestedProps') ?? [])]).toEqual([1]);
+});
+
+it('lets a caller-supplied limit collapse even directly requested shapes', () => {
+	const moduleDefinition = parseFromProgram(propertyCountLimitInput, program, {
+		shouldResolveObject: ({ propertyCount }) => propertyCount <= 10,
+	});
+	const serializedModuleDefinition = JSON.parse(JSON.stringify(moduleDefinition));
+	const componentExport = serializedModuleDefinition.exports.find(
+		(exportNode: { name: string }) => exportNode.name === 'ManyPropsComponent',
+	);
+
+	// The 51-property member is dropped by the caller's rule, leaving only the
+	// props contributed by the small members.
+	expect(componentExport.type.props.map((prop: { name: string }) => prop.name)).toEqual([
+		'extra',
+		'nested',
+		'forced',
+	]);
 });

--- a/src/parsers/typeResolvers/objectTypeResolver.ts
+++ b/src/parsers/typeResolvers/objectTypeResolver.ts
@@ -62,13 +62,25 @@ function buildIndexSignatureNode(
 	context: ScopedParserContext,
 	resolveValueType: ResolveTypeInContext,
 ): IndexSignatureNode | undefined {
-	const { checker } = context;
-
 	// Only check index signatures on actual object types
 	// Conditional types and other non-object types may report index signatures incorrectly
 	if (!isObjectType(type)) {
 		return undefined;
 	}
+
+	// The value type sits behind an (open-ended) property of this object, so it
+	// resolves one property level deeper than the object itself.
+	return context.runWithPropertyValueScope(() =>
+		buildIndexSignatureNodeCore(type, context, resolveValueType),
+	);
+}
+
+function buildIndexSignatureNodeCore(
+	type: ts.ObjectType,
+	context: ScopedParserContext,
+	resolveValueType: ResolveTypeInContext,
+): IndexSignatureNode | undefined {
+	const { checker } = context;
 
 	// Helper to extract key parameter name from index signature declaration
 	const getKeyName = (indexInfo: ts.IndexInfo): string | undefined => {
@@ -207,7 +219,8 @@ function buildObjectNodeFromType(
 	context: ScopedParserContext,
 	resolveValueType: ResolveTypeInContext,
 ): ObjectNode | undefined {
-	const { shouldInclude, shouldResolveObject, typeStack, includeExternalTypes } = context;
+	const { shouldInclude, shouldResolveObject, typeStack, includeExternalTypes, propertyDepth } =
+		context;
 
 	const properties = type
 		.getProperties()
@@ -223,6 +236,7 @@ function buildObjectNodeFromType(
 				name: typeName?.name ?? '',
 				propertyCount: properties.length,
 				depth: typeStack.length,
+				propertyDepth,
 			})
 		) {
 			let filteredProperties: ts.Symbol[];
@@ -335,10 +349,12 @@ function buildPropertyNodeFromSymbol(
 					type = checker.getTypeOfSymbol(propertySymbol);
 				}
 
-				const parsedType = resolvePropertyType(
-					type,
-					isTypeParameterLike(type) ? undefined : propertySignature?.type,
-					context,
+				const parsedType = context.runWithPropertyValueScope(() =>
+					resolvePropertyType(
+						type,
+						isTypeParameterLike(type) ? undefined : propertySignature?.type,
+						context,
+					),
 				);
 
 				// Typechecker only gives the type "any" if it's present in a union.

--- a/test/fixtures/object-property-count-limit-scope/input.tsx
+++ b/test/fixtures/object-property-count-limit-scope/input.tsx
@@ -1,0 +1,140 @@
+import * as React from 'react';
+
+// The default `shouldResolveObject` property-count limit keeps the parser from
+// expanding large shapes that nobody asked about. It must not apply to the
+// shapes a caller did ask about - the exported alias and the component props
+// below - because dropping their properties silently empties the output.
+
+interface ManyProps {
+	p01: string;
+	p02: string;
+	p03: string;
+	p04: string;
+	p05: string;
+	p06: string;
+	p07: string;
+	p08: string;
+	p09: string;
+	p10: string;
+	p11: string;
+	p12: string;
+	p13: string;
+	p14: string;
+	p15: string;
+	p16: string;
+	p17: string;
+	p18: string;
+	p19: string;
+	p20: string;
+	p21: string;
+	p22: string;
+	p23: string;
+	p24: string;
+	p25: string;
+	p26: string;
+	p27: string;
+	p28: string;
+	p29: string;
+	p30: string;
+	p31: string;
+	p32: string;
+	p33: string;
+	p34: string;
+	p35: string;
+	p36: string;
+	p37: string;
+	p38: string;
+	p39: string;
+	p40: string;
+	p41: string;
+	p42: string;
+	p43: string;
+	p44: string;
+	p45: string;
+	p46: string;
+	p47: string;
+	p48: string;
+	p49: string;
+	p50: string;
+	p51: string;
+}
+
+interface ManyNestedProps {
+	n01: string;
+	n02: string;
+	n03: string;
+	n04: string;
+	n05: string;
+	n06: string;
+	n07: string;
+	n08: string;
+	n09: string;
+	n10: string;
+	n11: string;
+	n12: string;
+	n13: string;
+	n14: string;
+	n15: string;
+	n16: string;
+	n17: string;
+	n18: string;
+	n19: string;
+	n20: string;
+	n21: string;
+	n22: string;
+	n23: string;
+	n24: string;
+	n25: string;
+	n26: string;
+	n27: string;
+	n28: string;
+	n29: string;
+	n30: string;
+	n31: string;
+	n32: string;
+	n33: string;
+	n34: string;
+	n35: string;
+	n36: string;
+	n37: string;
+	n38: string;
+	n39: string;
+	n40: string;
+	n41: string;
+	n42: string;
+	n43: string;
+	n44: string;
+	n45: string;
+	n46: string;
+	n47: string;
+	n48: string;
+	n49: string;
+	n50: string;
+	n51: string;
+}
+
+interface ExtraProps {
+	extra?: boolean;
+	/**
+	 * A property value is a nested detail rather than the subject of the export,
+	 * so the property-count limit still collapses it to a bare object.
+	 */
+	nested?: ManyNestedProps;
+}
+
+/**
+ * Aggregates more than 50 properties through composition alone. Real-world
+ * component props reach the same shape through wrappers such as
+ * `Omit<Partial<ManyProps> & ExtraProps, 'p51'>`.
+ */
+export type ManyComponentProps = ManyProps &
+	ExtraProps & {
+		forced?: true;
+	};
+
+/**
+ * A component whose props exceed the default property-count limit.
+ */
+export function ManyPropsComponent(props: ManyComponentProps): React.JSX.Element {
+	return <div>{props.p01}</div>;
+}

--- a/test/fixtures/object-property-count-limit-scope/output.json
+++ b/test/fixtures/object-property-count-limit-scope/output.json
@@ -1,0 +1,1925 @@
+{
+	"name": "test/fixtures/object-property-count-limit-scope/input",
+	"exports": [
+		{
+			"name": "ManyPropsComponent",
+			"type": {
+				"kind": "component",
+				"typeName": {
+					"name": "ManyPropsComponent"
+				},
+				"props": [
+					{
+						"name": "p01",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p02",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p03",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p04",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p05",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p06",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p07",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p08",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p09",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p10",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p11",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p12",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p13",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p14",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p15",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p16",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p17",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p18",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p19",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p20",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p21",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p22",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p23",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p24",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p25",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p26",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p27",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p28",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p29",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p30",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p31",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p32",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p33",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p34",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p35",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p36",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p37",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p38",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p39",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p40",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p41",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p42",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p43",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p44",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p45",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p46",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p47",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p48",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p49",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p50",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "p51",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "extra",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "boolean"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "nested",
+						"type": {
+							"kind": "union",
+							"typeName": {
+								"name": "ManyNestedProps"
+							},
+							"types": [
+								{
+									"kind": "object",
+									"typeName": {
+										"name": "ManyNestedProps"
+									},
+									"properties": []
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"documentation": {
+							"description": "A property value is a nested detail rather than the subject of the export,\nso the property-count limit still collapses it to a bare object.",
+							"tags": []
+						},
+						"optional": true
+					},
+					{
+						"name": "forced",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "literal",
+									"value": "true"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					}
+				]
+			},
+			"documentation": {
+				"description": "A component whose props exceed the default property-count limit.",
+				"tags": []
+			}
+		},
+		{
+			"name": "ManyComponentProps",
+			"type": {
+				"kind": "intersection",
+				"typeName": {
+					"name": "ManyComponentProps"
+				},
+				"types": [
+					{
+						"kind": "object",
+						"typeName": {
+							"name": "ManyProps"
+						},
+						"properties": [
+							{
+								"name": "p01",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p02",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p03",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p04",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p05",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p06",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p07",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p08",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p09",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p10",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p11",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p12",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p13",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p14",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p15",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p16",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p17",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p18",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p19",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p20",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p21",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p22",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p23",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p24",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p25",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p26",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p27",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p28",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p29",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p30",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p31",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p32",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p33",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p34",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p35",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p36",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p37",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p38",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p39",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p40",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p41",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p42",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p43",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p44",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p45",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p46",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p47",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p48",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p49",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p50",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							},
+							{
+								"name": "p51",
+								"type": {
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								"optional": false
+							}
+						]
+					},
+					{
+						"kind": "object",
+						"typeName": {
+							"name": "ExtraProps"
+						},
+						"properties": [
+							{
+								"name": "extra",
+								"type": {
+									"kind": "union",
+									"types": [
+										{
+											"kind": "intrinsic",
+											"intrinsic": "boolean"
+										},
+										{
+											"kind": "intrinsic",
+											"intrinsic": "undefined"
+										}
+									]
+								},
+								"optional": true
+							},
+							{
+								"name": "nested",
+								"type": {
+									"kind": "union",
+									"typeName": {
+										"name": "ManyNestedProps"
+									},
+									"types": [
+										{
+											"kind": "object",
+											"typeName": {
+												"name": "ManyNestedProps"
+											},
+											"properties": []
+										},
+										{
+											"kind": "intrinsic",
+											"intrinsic": "undefined"
+										}
+									]
+								},
+								"documentation": {
+									"description": "A property value is a nested detail rather than the subject of the export,\nso the property-count limit still collapses it to a bare object.",
+									"tags": []
+								},
+								"optional": true
+							}
+						]
+					},
+					{
+						"kind": "object",
+						"properties": [
+							{
+								"name": "forced",
+								"type": {
+									"kind": "union",
+									"types": [
+										{
+											"kind": "literal",
+											"value": "true"
+										},
+										{
+											"kind": "intrinsic",
+											"intrinsic": "undefined"
+										}
+									]
+								},
+								"optional": true
+							}
+						]
+					}
+				],
+				"properties": [
+					{
+						"name": "p01",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p02",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p03",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p04",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p05",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p06",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p07",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p08",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p09",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p10",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p11",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p12",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p13",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p14",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p15",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p16",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p17",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p18",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p19",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p20",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p21",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p22",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p23",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p24",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p25",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p26",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p27",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p28",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p29",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p30",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p31",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p32",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p33",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p34",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p35",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p36",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p37",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p38",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p39",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p40",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p41",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p42",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p43",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p44",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p45",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p46",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p47",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p48",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p49",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p50",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "p51",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					},
+					{
+						"name": "extra",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "boolean"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "nested",
+						"type": {
+							"kind": "union",
+							"typeName": {
+								"name": "ManyNestedProps"
+							},
+							"types": [
+								{
+									"kind": "object",
+									"typeName": {
+										"name": "ManyNestedProps"
+									},
+									"properties": []
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"documentation": {
+							"description": "A property value is a nested detail rather than the subject of the export,\nso the property-count limit still collapses it to a bare object.",
+							"tags": []
+						},
+						"optional": true
+					},
+					{
+						"name": "forced",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "literal",
+									"value": "true"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					}
+				]
+			},
+			"documentation": {
+				"description": "Aggregates more than 50 properties through composition alone. Real-world\ncomponent props reach the same shape through wrappers such as\n`Omit<Partial<ManyProps> & ExtraProps, 'p51'>`.",
+				"tags": []
+			}
+		}
+	],
+	"imports": ["react"]
+}

--- a/test/fixtures/react-component-return-types/input.tsx
+++ b/test/fixtures/react-component-return-types/input.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { type ReactElement, type ReactNode } from 'react';
+
+// A component is recognized by the name of what it returns, in whichever form
+// the author declared it.
+
+export function NamespacedElement(props: { a?: string }): React.JSX.Element {
+	return <div>{props.a}</div>;
+}
+
+export function BareElement(props: { a?: string }): ReactElement {
+	return <div>{props.a}</div>;
+}
+
+export function GenericElement(props: { a?: string }): ReactElement<{ b: string }> {
+	return <div>{props.a}</div>;
+}
+
+export function BareNode(props: { a?: string }): ReactNode {
+	return <div>{props.a}</div>;
+}
+
+export function NullableElement(props: { a?: string }): React.JSX.Element | null {
+	return props.a ? <div>{props.a}</div> : null;
+}
+
+export function InferredElement(props: { a?: string }) {
+	return <div>{props.a}</div>;
+}
+
+interface ListElement {
+	tag: string;
+}
+
+/**
+ * A local type whose name merely ends in `Element` does not make a component.
+ */
+export function LocalElementType(props: { a?: string }): ListElement {
+	return { tag: props.a ?? '' };
+}
+
+/**
+ * Neither does a DOM element.
+ */
+export function DomElementType(props: { a?: string }): HTMLElement {
+	return document.createElement(props.a ?? 'div');
+}

--- a/test/fixtures/react-component-return-types/output.json
+++ b/test/fixtures/react-component-return-types/output.json
@@ -1,0 +1,286 @@
+{
+	"name": "test/fixtures/react-component-return-types/input",
+	"exports": [
+		{
+			"name": "NamespacedElement",
+			"type": {
+				"kind": "component",
+				"typeName": {
+					"name": "NamespacedElement"
+				},
+				"props": [
+					{
+						"name": "a",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					}
+				]
+			}
+		},
+		{
+			"name": "BareElement",
+			"type": {
+				"kind": "component",
+				"typeName": {
+					"name": "BareElement"
+				},
+				"props": [
+					{
+						"name": "a",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					}
+				]
+			}
+		},
+		{
+			"name": "GenericElement",
+			"type": {
+				"kind": "component",
+				"typeName": {
+					"name": "GenericElement"
+				},
+				"props": [
+					{
+						"name": "a",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					}
+				]
+			}
+		},
+		{
+			"name": "BareNode",
+			"type": {
+				"kind": "component",
+				"typeName": {
+					"name": "BareNode"
+				},
+				"props": [
+					{
+						"name": "a",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					}
+				]
+			}
+		},
+		{
+			"name": "NullableElement",
+			"type": {
+				"kind": "component",
+				"typeName": {
+					"name": "NullableElement"
+				},
+				"props": [
+					{
+						"name": "a",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					}
+				]
+			}
+		},
+		{
+			"name": "InferredElement",
+			"type": {
+				"kind": "component",
+				"typeName": {
+					"name": "InferredElement"
+				},
+				"props": [
+					{
+						"name": "a",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					}
+				]
+			}
+		},
+		{
+			"name": "LocalElementType",
+			"type": {
+				"kind": "function",
+				"typeName": {
+					"name": "LocalElementType"
+				},
+				"callSignatures": [
+					{
+						"parameters": [
+							{
+								"type": {
+									"kind": "object",
+									"properties": [
+										{
+											"name": "a",
+											"type": {
+												"kind": "union",
+												"types": [
+													{
+														"kind": "intrinsic",
+														"intrinsic": "string"
+													},
+													{
+														"kind": "intrinsic",
+														"intrinsic": "undefined"
+													}
+												]
+											},
+											"optional": true
+										}
+									]
+								},
+								"name": "props",
+								"optional": false
+							}
+						],
+						"returnValueType": {
+							"kind": "object",
+							"typeName": {
+								"name": "ListElement"
+							},
+							"properties": [
+								{
+									"name": "tag",
+									"type": {
+										"kind": "intrinsic",
+										"intrinsic": "string"
+									},
+									"optional": false
+								}
+							]
+						}
+					}
+				]
+			},
+			"documentation": {
+				"description": "A local type whose name merely ends in `Element` does not make a component.",
+				"tags": []
+			}
+		},
+		{
+			"name": "DomElementType",
+			"type": {
+				"kind": "function",
+				"typeName": {
+					"name": "DomElementType"
+				},
+				"callSignatures": [
+					{
+						"parameters": [
+							{
+								"type": {
+									"kind": "object",
+									"properties": [
+										{
+											"name": "a",
+											"type": {
+												"kind": "union",
+												"types": [
+													{
+														"kind": "intrinsic",
+														"intrinsic": "string"
+													},
+													{
+														"kind": "intrinsic",
+														"intrinsic": "undefined"
+													}
+												]
+											},
+											"optional": true
+										}
+									]
+								},
+								"name": "props",
+								"optional": false
+							}
+						],
+						"returnValueType": {
+							"kind": "external",
+							"typeName": {
+								"name": "HTMLElement"
+							}
+						}
+					}
+				]
+			},
+			"documentation": {
+				"description": "Neither does a DOM element.",
+				"tags": []
+			}
+		}
+	],
+	"imports": ["react", "react"]
+}

--- a/test/fixtures/react-component-union-variants/input.tsx
+++ b/test/fixtures/react-component-union-variants/input.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+
+// Polymorphic components pick their implementation at module scope, so their
+// exported type is a union of component types rather than a single one. Each arm
+// describes the same component under a different prop form, and the extractor
+// should report one merged prop table instead of a bare union.
+
+declare const supportsRender: boolean;
+
+interface ToolbarProps {
+	children?: React.ReactNode;
+	/**
+	 * Class applied to the root element.
+	 */
+	className?: string;
+}
+
+interface RenderToolbarProps {
+	/**
+	 * Renders the root element itself.
+	 */
+	render: (props: { className?: string }) => React.ReactElement;
+	className?: string;
+}
+
+const ToolbarRoot = React.forwardRef(function Toolbar(
+	props: ToolbarProps,
+	ref: React.Ref<HTMLDivElement>,
+) {
+	return <div ref={ref}>{props.children}</div>;
+});
+
+const ToolbarWithRender = React.forwardRef(function Toolbar(
+	props: RenderToolbarProps,
+	ref: React.Ref<HTMLDivElement>,
+) {
+	return <div ref={ref}>{props.render({ className: props.className })}</div>;
+});
+
+/**
+ * A toolbar that renders either its own root element or a caller-supplied one.
+ */
+export const Toolbar = supportsRender ? ToolbarWithRender : ToolbarRoot;
+
+/**
+ * Not every union of a component is a component: an arm that is not itself
+ * component-like keeps the export a plain union.
+ */
+export const OptionalToolbar = supportsRender ? ToolbarRoot : undefined;

--- a/test/fixtures/react-component-union-variants/output.json
+++ b/test/fixtures/react-component-union-variants/output.json
@@ -1,0 +1,390 @@
+{
+	"name": "test/fixtures/react-component-union-variants/input",
+	"exports": [
+		{
+			"name": "Toolbar",
+			"type": {
+				"kind": "component",
+				"props": [
+					{
+						"name": "render",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "function",
+									"callSignatures": [
+										{
+											"parameters": [
+												{
+													"type": {
+														"kind": "object",
+														"properties": [
+															{
+																"name": "className",
+																"type": {
+																	"kind": "union",
+																	"types": [
+																		{
+																			"kind": "intrinsic",
+																			"intrinsic": "string"
+																		},
+																		{
+																			"kind": "intrinsic",
+																			"intrinsic": "undefined"
+																		}
+																	]
+																},
+																"optional": true
+															}
+														]
+													},
+													"name": "props",
+													"optional": false
+												}
+											],
+											"returnValueType": {
+												"kind": "external",
+												"typeName": {
+													"name": "ReactElement",
+													"namespaces": ["React"],
+													"typeArguments": [
+														{
+															"type": {
+																"kind": "intrinsic",
+																"intrinsic": "unknown"
+															},
+															"equalToDefault": true
+														},
+														{
+															"type": {
+																"kind": "union",
+																"types": [
+																	{
+																		"kind": "intrinsic",
+																		"intrinsic": "string"
+																	},
+																	{
+																		"kind": "external",
+																		"typeName": {
+																			"name": "JSXElementConstructor",
+																			"namespaces": ["React"],
+																			"typeArguments": [
+																				{
+																					"type": {
+																						"kind": "intrinsic",
+																						"intrinsic": "any"
+																					},
+																					"equalToDefault": false
+																				}
+																			]
+																		}
+																	}
+																]
+															},
+															"equalToDefault": true
+														}
+													]
+												}
+											}
+										}
+									]
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"documentation": {
+							"description": "Renders the root element itself.",
+							"tags": []
+						},
+						"optional": true
+					},
+					{
+						"name": "className",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "intrinsic",
+									"intrinsic": "string"
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					},
+					{
+						"name": "children",
+						"type": {
+							"kind": "union",
+							"types": [
+								{
+									"kind": "external",
+									"typeName": {
+										"name": "ReactNode",
+										"namespaces": ["React"]
+									}
+								},
+								{
+									"kind": "intrinsic",
+									"intrinsic": "undefined"
+								}
+							]
+						},
+						"optional": true
+					}
+				]
+			},
+			"documentation": {
+				"description": "A toolbar that renders either its own root element or a caller-supplied one.",
+				"tags": []
+			}
+		},
+		{
+			"name": "OptionalToolbar",
+			"type": {
+				"kind": "union",
+				"types": [
+					{
+						"kind": "function",
+						"typeName": {
+							"name": "ForwardRefExoticComponent",
+							"namespaces": ["React"],
+							"typeArguments": [
+								{
+									"type": {
+										"kind": "intersection",
+										"types": [
+											{
+												"kind": "object",
+												"typeName": {
+													"name": "ToolbarProps"
+												},
+												"properties": [
+													{
+														"name": "children",
+														"type": {
+															"kind": "external",
+															"typeName": {
+																"name": "ReactNode",
+																"namespaces": ["React"]
+															}
+														},
+														"optional": true
+													},
+													{
+														"name": "className",
+														"type": {
+															"kind": "union",
+															"types": [
+																{
+																	"kind": "intrinsic",
+																	"intrinsic": "string"
+																},
+																{
+																	"kind": "intrinsic",
+																	"intrinsic": "undefined"
+																}
+															]
+														},
+														"documentation": {
+															"description": "Class applied to the root element.",
+															"tags": []
+														},
+														"optional": true
+													}
+												]
+											},
+											{
+												"kind": "external",
+												"typeName": {
+													"name": "RefAttributes",
+													"namespaces": ["React"],
+													"typeArguments": [
+														{
+															"type": {
+																"kind": "external",
+																"typeName": {
+																	"name": "HTMLDivElement"
+																}
+															},
+															"equalToDefault": false
+														}
+													]
+												}
+											}
+										],
+										"properties": [
+											{
+												"name": "children",
+												"type": {
+													"kind": "external",
+													"typeName": {
+														"name": "ReactNode",
+														"namespaces": ["React"]
+													}
+												},
+												"optional": true
+											},
+											{
+												"name": "className",
+												"type": {
+													"kind": "union",
+													"types": [
+														{
+															"kind": "intrinsic",
+															"intrinsic": "string"
+														},
+														{
+															"kind": "intrinsic",
+															"intrinsic": "undefined"
+														}
+													]
+												},
+												"documentation": {
+													"description": "Class applied to the root element.",
+													"tags": []
+												},
+												"optional": true
+											}
+										]
+									},
+									"equalToDefault": false
+								}
+							]
+						},
+						"callSignatures": [
+							{
+								"parameters": [
+									{
+										"type": {
+											"kind": "intersection",
+											"types": [
+												{
+													"kind": "object",
+													"typeName": {
+														"name": "ToolbarProps"
+													},
+													"properties": [
+														{
+															"name": "children",
+															"type": {
+																"kind": "external",
+																"typeName": {
+																	"name": "ReactNode",
+																	"namespaces": ["React"]
+																}
+															},
+															"optional": true
+														},
+														{
+															"name": "className",
+															"type": {
+																"kind": "union",
+																"types": [
+																	{
+																		"kind": "intrinsic",
+																		"intrinsic": "string"
+																	},
+																	{
+																		"kind": "intrinsic",
+																		"intrinsic": "undefined"
+																	}
+																]
+															},
+															"documentation": {
+																"description": "Class applied to the root element.",
+																"tags": []
+															},
+															"optional": true
+														}
+													]
+												},
+												{
+													"kind": "external",
+													"typeName": {
+														"name": "RefAttributes",
+														"namespaces": ["React"],
+														"typeArguments": [
+															{
+																"type": {
+																	"kind": "external",
+																	"typeName": {
+																		"name": "HTMLDivElement"
+																	}
+																},
+																"equalToDefault": false
+															}
+														]
+													}
+												}
+											],
+											"properties": [
+												{
+													"name": "children",
+													"type": {
+														"kind": "external",
+														"typeName": {
+															"name": "ReactNode",
+															"namespaces": ["React"]
+														}
+													},
+													"optional": true
+												},
+												{
+													"name": "className",
+													"type": {
+														"kind": "union",
+														"types": [
+															{
+																"kind": "intrinsic",
+																"intrinsic": "string"
+															},
+															{
+																"kind": "intrinsic",
+																"intrinsic": "undefined"
+															}
+														]
+													},
+													"documentation": {
+														"description": "Class applied to the root element.",
+														"tags": []
+													},
+													"optional": true
+												}
+											]
+										},
+										"name": "props",
+										"optional": false
+									}
+								],
+								"returnValueType": {
+									"kind": "external",
+									"typeName": {
+										"name": "ReactNode",
+										"namespaces": ["React"]
+									}
+								}
+							}
+						]
+					},
+					{
+						"kind": "intrinsic",
+						"intrinsic": "undefined"
+					}
+				]
+			},
+			"documentation": {
+				"description": "Not every union of a component is a component: an arm that is not itself\ncomponent-like keeps the export a plain union.",
+				"tags": []
+			}
+		}
+	],
+	"imports": ["react"]
+}

--- a/test/support/parserContext.ts
+++ b/test/support/parserContext.ts
@@ -32,6 +32,7 @@ export function createTestParserContext(program: ts.Program, filePath: string): 
 		parsedSymbolStack,
 		sourceNodeStack,
 		program,
+		propertyDepth: 0,
 		resolvedTypeCache: new Map<string, AnyType>(),
 		shouldInclude: () => true,
 		shouldResolveObject: () => true,
@@ -47,6 +48,15 @@ export function createTestParserContext(program: ts.Program, filePath: string): 
 			}
 
 			return runWithStackEntryScope(sourceNodeStack, sourceNode, callback);
+		},
+		runWithPropertyValueScope: (callback) => {
+			context.propertyDepth += 1;
+
+			try {
+				return callback();
+			} finally {
+				context.propertyDepth -= 1;
+			}
 		},
 		runWithTypeParameterSubstitutionScope: (typeParameterSubstitutions, callback) => {
 			const previousTypeParameterSubstitutions = context.typeParameterSubstitutions;


### PR DESCRIPTION
Supersedes #105.

That PR reported three problems found while running the extractor against mui-x. Two are still reproducible on `main`; the third (`isGenericArgumentsSameAsDefault` crashing on a type parameter with no declaration) was fixed independently in #153, and the `typescript` peer bump it asked for landed in #154. The parser has since been restructured, so its patch no longer applies — this is a fresh implementation, plus a related detection bug found while verifying.

## What this fixes

### 1. Large prop lists collapsed to an empty object

`shouldResolveObject`'s default `propertyCount <= 50` rule applied at every depth, including the type a caller directly asked about. A component with more than 50 props reported almost none of them, and an exported alias over the same shape lost its properties entirely. The limit exists to bound recursion into nested shapes, not to hide the shape being documented.

`shouldResolveObject` now also receives `propertyDepth`: how many property (or index signature) values were traversed to reach the object. It is `0` for the export's own type and for everything reached from it through composition alone — aliases, unions, intersections, and the parameter and return types of its call signatures. The default rule becomes:

```
(propertyDepth === 0 || propertyCount <= 50) && depth <= 10
```

so the property-count limit only applies where unbounded expansion is the actual risk. `depth <= 10` is unchanged, and resolved types are now cached per property depth as well, since the same type resolves to a different shape on either side of the limit.

On the DataGrid-shaped regression input, the component goes from 1 prop to 55.

### 2. Polymorphic components classified as unions

A component that picks its implementation at module scope has a union of function types, one arm per prop form, and the component transform only recognized a single function. It now accepts a union whose every arm is component-like and squashes the arms' call signatures into one prop list, leaving props specific to a single arm optional. Unions with a non-component arm keep their union shape.

On `@mui/x-data-grid@9.10.1` this moves 42 exports (`Toolbar`, `GridRow`, `ExportCsv`, `QuickFilter*`, …) from `union` to `component`.

### 3. No components detected at all under `includeExternalTypes: true`

Found while verifying the above. `hasReactNodeLikeReturnType` matched on `instanceof ExternalTypeNode`, which is not a property of React's types but of how the parser chose to summarize them. With `includeExternalTypes: true` the same types expand into objects and unions, so nothing matched and no export was recognized as a component — not even a plain function component.

Detection now matches the return type's name on whichever node carries it, and descends into union members so `JSX.Element | null` still counts. Names are matched exactly rather than by substring; see the breaking changes below.

## Breaking changes

**Exports that were `kind: "union"` may now be `kind: "component"`.** Any export whose type is a union of React-returning functions is now a single `ComponentNode` with a merged prop table. Consumers switching on `kind` will see a structurally different node.

**Exports that were `kind: "component"` may now be `kind: "function"`.** The old return-type match used the substring `/Element/`, so a capitalized function returning `HTMLElement` — or any type whose name merely ends in `Element` — was treated as a component. Detection now matches `Element`, `ReactElement`, and `ReactNode` exactly. This also drops rarely-declared React types such as `React.FunctionComponentElement`; a component declared as returning `ReactElement` is unaffected.

**Under `includeExternalTypes: true`, exports that were `kind: "function"` are now `kind: "component"`.** Previously no component was detected in that mode at all.

**Objects with more than 50 properties now carry their properties.** Wherever such an object sits at `propertyDepth 0`, output that was previously an empty object node now contains the full property list. Output grows accordingly for affected inputs.

**`ParserContext` gained a required `propertyDepth: number` field.** This is a type-level break only for code that constructs a `ParserContext` itself to drive parser internals. `parseFile` and `parseFromProgram` callers are unaffected.

## Migration

**If you snapshot the extractor's output**, expect diffs on the four output changes above. Regenerate and review.

**If you branch on `ExportNode.type.kind`**, check the `union` and `function` branches for exports that are now `component`, and confirm nothing depended on a non-React `*Element` return type being classified as a component.

**If you supply `shouldResolveObject`, check whether it restates the old default.** A predicate like

```ts
shouldResolveObject: ({ propertyCount, depth }) => propertyCount <= 50 && depth <= 10
```

still returns a definite `false` for large shapes, so it keeps the old collapsing behavior — an explicit return always wins over the default. To pick up the fix, add the property-depth exemption:

```ts
shouldResolveObject: ({ propertyCount, depth, propertyDepth }) =>
  (propertyDepth === 0 || propertyCount <= 50) && depth <= 10
```

Predicates that return `undefined` to defer to the default need no change, and existing callback signatures still typecheck: a callback declared with only `name`, `propertyCount`, and `depth` remains assignable.

**If you construct a `ParserContext`**, add `propertyDepth: 0`.

## Testing

`pnpm typecheck`, `pnpm typecheck:test-inputs`, `pnpm lint`, `pnpm test` — all green, 163 tests. No existing fixture output changed.

New coverage:

- `test/fixtures/object-property-count-limit-scope` — a 51-property shape reached through composition is enumerated in full, both as an exported alias and as component props, while a 51-property shape behind a property still collapses.
- `test/fixtures/react-component-union-variants` — a polymorphic component union merges into one prop table; a union with a non-component arm stays a union.
- `test/fixtures/react-component-return-types` — six ways of declaring a React return type are detected; a local `ListElement` and a DOM `HTMLElement` are not.
- `src/parsers/componentParser.test.ts` — the two `includeExternalTypes` modes classify identically. The fixture harness only runs default options, so this half had to be a unit test.
- Unit tests for union classification, prop merging, and component type-name handling; for `propertyDepth` being reported correctly; and for a caller-supplied `shouldResolveObject` still overriding the relaxed default.

Verified end to end against `@mui/x-data-grid@9.10.1`: components detected go from 3 to 45 with default options, and all 42 union-shaped exports resolve to `component`. Parsing the full export surface goes from 1.47s to 1.68s, the cost of actually expanding 45 prop tables instead of 3.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
