### PR TITLE
1.0.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ breaking changes below before upgrading.
 
   ```ts
   case 'typeOperator':
-  	return format(node.resolvedType);
+  	return node.resolvedType ? format(node.resolvedType) : `${node.operator} ${format(node.type)}`;
   case 'typeQuery':
   	return `typeof ${node.expressionName}`;
   ```
+
+  The exported `TypeOperatorNode` class describes both output modes, so `resolvedType` is optional on it and a formatter typed against `TypeNode` needs the guard above. Output typed as `ResolvedModuleNode` - what default and literal `'resolved'` calls return - always carries the field, so `format(node.resolvedType)` alone typechecks there.
 
   To adopt the preserved syntax - which is what collapses, say, a 178-member `keyof React.JSX.IntrinsicElements` union into one readable line - format the operator itself:
 
@@ -28,11 +30,11 @@ breaking changes below before upgrading.
   	return `${node.operator} ${format(node.type)}`;
   ```
 
-  `resolutionKind` tells you how far to trust `resolvedType`: `exact` is equivalent to the operator, `baseConstraint` is a still-generic operand's constraint rather than its eventual instantiated result (`keyof T` commonly resolves to `string | number | symbol` at extraction time), and `fallback` is a recoverable degradation. Every model node also implements `toString()`, so `String(node)` renders `keyof React.JSX.IntrinsicElements` without touching your switch at all.
+  `resolutionKind` tells you how far to trust `resolvedType`: `exact` is equivalent to the operator, `baseConstraint` is a still-generic operand's constraint rather than its eventual instantiated result (`keyof T` commonly resolves to `string | number | symbol` at extraction time), and `fallback` is a recoverable degradation. Every type node also implements `toString()`, so `String(node)` renders `keyof React.JSX.IntrinsicElements` without touching your switch at all.
 
 - Some exports change their `kind` as a result of the React component detection fixes. An export whose type is a union of React-returning functions is now a `component` with one merged prop list instead of a `union`. Conversely, a capitalized function whose return type merely ends in `Element` - a local `ListElement`, or the DOM's `HTMLElement` - is now a `function` instead of a `component`, because return types are matched exactly against `Element`, `ReactElement`, and `ReactNode`. Under `includeExternalTypes: true`, exports that were `function` become `component`, since no component was detected in that mode at all before. If you branch on `ExportNode.type.kind`, review the `union` and `function` branches, and confirm nothing depended on a non-React `*Element` return type being classified as a component. [#212](https://github.com/michaldudak/typescript-api-extractor/pull/212)
 
-- Objects with more than 50 properties now report their properties instead of collapsing to an empty object, wherever they sit at `propertyDepth` 0. Output grows accordingly for affected inputs; regenerate and review any snapshots. If you pass a `shouldResolveObject` that restates the old default, it keeps the old collapsing behavior, because an explicit return always wins over the default. [#212](https://github.com/michaldudak/typescript-api-extractor/pull/212)
+- Objects with more than 50 properties now report their properties instead of collapsing to an empty object when they sit at `propertyDepth` 0. Only the property-count limit is lifted there; the `depth <= 10` limit on the resolution stack is unchanged, so a shape reached through more than ten composition frames still collapses. Output grows accordingly for affected inputs; regenerate and review any snapshots. If you pass a `shouldResolveObject` that restates the old default, it keeps the old collapsing behavior, because an explicit return always wins over the default. [#212](https://github.com/michaldudak/typescript-api-extractor/pull/212)
 
   Add the property-depth exemption to pick up the fix:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Changelog
 
+## v1.0.0-beta.6
+
+_August 10, 2026_
+
+This release preserves authored `keyof` syntax in the output model and fixes three
+React component extraction problems. Both change the emitted model, so read the
+breaking changes below before upgrading.
+
+### Breaking changes
+
+- `TypeNode.kind` has two new discriminants: `typeOperator` and `typeQuery`. Authored `keyof` expressions are no longer expanded into their key union in place - they are preserved as a `TypeOperatorNode` carrying the authored operand (`type`), the checker result (`resolvedType`), and how that result was obtained (`resolutionKind`). A `typeof` operand becomes a `TypeQueryNode` with an `expressionName`. Nothing is lost from the model: `resolvedType` holds exactly what the previous release emitted in that position. The failure mode is silent, however - a formatter whose dispatch chain ends in a default return emits that default for every `keyof` in the API instead of throwing. [#142](https://github.com/michaldudak/typescript-api-extractor/pull/142)
+
+  To keep the previous output unchanged, format `resolvedType`:
+
+  ```ts
+  case 'typeOperator':
+  	return format(node.resolvedType);
+  case 'typeQuery':
+  	return `typeof ${node.expressionName}`;
+  ```
+
+  To adopt the preserved syntax - which is what collapses, say, a 178-member `keyof React.JSX.IntrinsicElements` union into one readable line - format the operator itself:
+
+  ```ts
+  case 'typeOperator':
+  	return `${node.operator} ${format(node.type)}`;
+  ```
+
+  `resolutionKind` tells you how far to trust `resolvedType`: `exact` is equivalent to the operator, `baseConstraint` is a still-generic operand's constraint rather than its eventual instantiated result (`keyof T` commonly resolves to `string | number | symbol` at extraction time), and `fallback` is a recoverable degradation. Every model node also implements `toString()`, so `String(node)` renders `keyof React.JSX.IntrinsicElements` without touching your switch at all.
+
+- Some exports change their `kind` as a result of the React component detection fixes. An export whose type is a union of React-returning functions is now a `component` with one merged prop list instead of a `union`. Conversely, a capitalized function whose return type merely ends in `Element` - a local `ListElement`, or the DOM's `HTMLElement` - is now a `function` instead of a `component`, because return types are matched exactly against `Element`, `ReactElement`, and `ReactNode`. Under `includeExternalTypes: true`, exports that were `function` become `component`, since no component was detected in that mode at all before. If you branch on `ExportNode.type.kind`, review the `union` and `function` branches, and confirm nothing depended on a non-React `*Element` return type being classified as a component. [#212](https://github.com/michaldudak/typescript-api-extractor/pull/212)
+
+- Objects with more than 50 properties now report their properties instead of collapsing to an empty object, wherever they sit at `propertyDepth` 0. Output grows accordingly for affected inputs; regenerate and review any snapshots. If you pass a `shouldResolveObject` that restates the old default, it keeps the old collapsing behavior, because an explicit return always wins over the default. [#212](https://github.com/michaldudak/typescript-api-extractor/pull/212)
+
+  Add the property-depth exemption to pick up the fix:
+
+  ```ts
+  shouldResolveObject: ({ propertyCount, depth, propertyDepth }) =>
+  	(propertyDepth === 0 || propertyCount <= 50) && depth <= 10;
+  ```
+
+  Predicates that return `undefined` to defer to the default need no change, and a callback declared with only `name`, `propertyCount`, and `depth` still typechecks.
+
+- Readonly arrays and tuples now serialize `isReadonly: true` and render as `readonly T[]` and `readonly [A, B]`. The field is omitted for mutable containers. [#142](https://github.com/michaldudak/typescript-api-extractor/pull/142)
+
+- `ParserContext` gained a required `propertyDepth: number` field. This is a type-level break only for code that constructs a `ParserContext` itself to drive parser internals; add `propertyDepth: 0`. `parseFile` and `parseFromProgram` callers are unaffected. [#212](https://github.com/michaldudak/typescript-api-extractor/pull/212)
+
+### New features
+
+- Added the `typeOperatorOutput` parser option. Set it to `'syntaxOnly'` to omit `resolvedType` and `resolutionKind` from preserved operators, which avoids storing large key unions such as `keyof React.JSX.IntrinsicElements`. The default is `'resolved'`. Note that this is not an escape hatch from the migration above - it removes the resolved payload, so it requires the operator-formatting branch. [#142](https://github.com/michaldudak/typescript-api-extractor/pull/142)
+- `parseFile` and `parseFromProgram` now correlate their return type with the selected mode: `ResolvedModuleNode` for default and literal `'resolved'` calls, `SyntaxOnlyModuleNode` for literal `'syntaxOnly'` calls, and their union for a dynamic `ParserOptions` value. Both remain assignable to `ModuleNode`, so existing annotations keep typechecking. [#142](https://github.com/michaldudak/typescript-api-extractor/pull/142)
+- `shouldResolveObject` now also receives `propertyDepth`: how many property or index signature values were traversed to reach the object. It is 0 for the export's own type and for everything reached from it through composition alone - aliases, unions, intersections, and the parameter and return types of its call signatures - so the property-count limit can be applied only where unbounded expansion is the actual risk. [#212](https://github.com/michaldudak/typescript-api-extractor/pull/212)
+
+### Bug fixes
+
+- `keyof` is now preserved through aliases, re-exports and barrels, generic substitutions, defaults and constraints, unions and intersections, conditional, mapped and indexed-access types, class and function members, and array and tuple containers. It is not reconstructed after TypeScript selector and inference utilities erase the authored syntax, so `ReturnType`, `Parameters`, `Awaited`, `ConstructorParameters`, `ThisParameterType`, and user-authored `infer` selectors still expose only their reduced semantic result. Fixes [#76](https://github.com/michaldudak/typescript-api-extractor/issues/76). [#142](https://github.com/michaldudak/typescript-api-extractor/pull/142)
+- Large prop lists are no longer dropped. The default `propertyCount <= 50` rule applied at every depth, including the type a caller directly asked about, so a component with more than 50 props reported almost none of them and an exported alias over the same shape lost its properties entirely. On a DataGrid-shaped input the component goes from 1 prop to 55. [#212](https://github.com/michaldudak/typescript-api-extractor/pull/212)
+- Polymorphic components whose type is a union of function types, one arm per prop form, are now recognized as a single component with the arms' call signatures squashed into one prop list; props specific to a single arm come out optional. Unions with a non-component arm keep their union shape. On `@mui/x-data-grid@9.10.1` this moves 42 exports from `union` to `component`. [#212](https://github.com/michaldudak/typescript-api-extractor/pull/212)
+- React components are now detected under `includeExternalTypes: true`. Detection tested `instanceof ExternalTypeNode`, which describes how the parser chose to summarize React's types rather than the types themselves, so nothing matched once they were expanded and no export was recognized as a component. [#212](https://github.com/michaldudak/typescript-api-extractor/pull/212)
+- Class getters are now reported as properties. [#142](https://github.com/michaldudak/typescript-api-extractor/pull/142)
+- Array types whose element is a function or a preserved operator now render with parentheses, so `(() => void)[]` no longer stringifies as `() => void[]`. [#142](https://github.com/michaldudak/typescript-api-extractor/pull/142)
+
+### Maintenance
+
+- Restructured type resolution around syntax-first resolvers: authored alias replay (`authoredTypeAlias.ts`), shared generic bindings (`authoredTypeReferenceBindings.ts`, `typeParameterBindings.ts`), container identity helpers (`typeContainerUtils.ts`), and the parser context factory (`parserContextFactory.ts`) shared by production entry points and focused tests. [#142](https://github.com/michaldudak/typescript-api-extractor/pull/142)
+- Added a TypeScript 5.8 compatibility CI job. [#142](https://github.com/michaldudak/typescript-api-extractor/pull/142)
+- Refreshed dev and CI dependencies, including `@types/react`, pnpm, Node, `tsx`, `typescript-eslint`, Vite, and GitHub Actions, and updated transitive dependencies to clear the `brace-expansion` and `esbuild` advisories. [#205](https://github.com/michaldudak/typescript-api-extractor/pull/205)-[#213](https://github.com/michaldudak/typescript-api-extractor/pull/213)
+
 ## v1.0.0-beta.5
 
 _August 6, 2026_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "typescript-api-extractor",
-	"version": "1.0.0-beta.5",
+	"version": "1.0.0-beta.6",
 	"description": "Extracts API description from TypeScript code",
 	"author": {
 		"name": "Michał Dudak",


### PR DESCRIPTION
Bumps the version to `1.0.0-beta.6` and adds the changelog entry. No source changes.

The release covers two feature PRs and the dependency refresh since `v1.0.0-beta.5`:

- #142 — preserve authored `keyof` type operators
- #212 — report large prop lists and union-shaped components
- #205-#213 — dependency updates, including the `brace-expansion` and `esbuild` advisories

## Breaking changes

Both feature PRs change the emitted model, so the changelog entry carries migration steps for each:

1. **Two new `TypeNode.kind` discriminants**, `typeOperator` and `typeQuery`. The failure mode is silent — a formatter whose dispatch chain ends in a default return emits that default for every `keyof` in the API. Migration covers both the no-diff path (format `resolvedType`) and the adopt-the-feature path (format the operator).
2. **Exports change `kind`**: `union` → `component` for polymorphic components, `component` → `function` for non-React `*Element` return types, and `function` → `component` under `includeExternalTypes: true`.
3. **Objects with more than 50 properties now carry their properties** at `propertyDepth` 0. A `shouldResolveObject` that restates the old default silently keeps the old collapsing behavior.
4. **`isReadonly: true`** on readonly arrays and tuples.
5. **`ParserContext.propertyDepth`** is now required — type-level only, for code driving parser internals.

## Verification

- `pnpm prettier`
- `pnpm typecheck`
- `pnpm typecheck:test-inputs`
- `pnpm lint`
- `pnpm test` — 22 files, 287 tests, all passing

Separately typechecked that `ResolvedModuleNode` and `SyntaxOnlyModuleNode` remain assignable to `ModuleNode`, which the changelog claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)