### PR TITLE
Report declaration spaces on ExportNode

### DIFF
--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -15,11 +15,32 @@ interface ExportNode {
 	name: string;
 	type: TypeNode;
 	documentation?: DocumentationNode;
+	isValue: boolean;
+	isType: boolean;
+	isNamespace: boolean;
 }
 ```
 
 `TypeNode` represents a TypeScript type. There are multiple classes of types. See
 the contents of the `src/models/types` directory to discover them.
+
+## Declaration Spaces
+
+`isValue`, `isType`, and `isNamespace` report which of TypeScript's declaration
+spaces the export occupies. `type` describes the resolved type shape, which does
+not identify the declaration form: `export type X = 'x'` and
+`export const x: X = 'x'` both resolve to the same literal type, and only the
+declaration spaces tell them apart.
+
+- `isValue`: the export exists at runtime — variables, functions, classes, enums.
+- `isType`: the export names a type — type aliases, interfaces, classes, enums.
+- `isNamespace`: the export declares a namespace or module.
+
+Merged declarations occupy every space their declarations occupy: a class is
+both a value and a type, `interface X {}` merged with `const X: X` is both, and
+a namespace containing only types is neither a value nor a type, only a
+namespace. Renamed and re-exported aliases report the spaces of the declaration
+they resolve to.
 
 ## Type Operators
 

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -32,15 +32,23 @@ not identify the declaration form: `export type X = 'x'` and
 `export const x: X = 'x'` both resolve to the same literal type, and only the
 declaration spaces tell them apart.
 
-- `isValue`: the export exists at runtime — variables, functions, classes, enums.
+- `isValue`: the export occupies the value space — variables, functions,
+  classes, enums. Note that `const enum` members are inlined by default
+  (`preserveConstEnums: false`), so a value export does not guarantee a runtime
+  binding in the emitted output.
 - `isType`: the export names a type — type aliases, interfaces, classes, enums.
-- `isNamespace`: the export declares a namespace or module.
+- `isNamespace`: the export declares a namespace or module. Expando assignments
+  (`fn.extra = ...`) do not count.
 
 Merged declarations occupy every space their declarations occupy: a class is
 both a value and a type, `interface X {}` merged with `const X: X` is both, and
 a namespace containing only types is neither a value nor a type, only a
 namespace. Renamed and re-exported aliases report the spaces of the declaration
-they resolve to.
+they resolve to, combined with any local declarations merged onto the alias. A
+type-only re-export (`export type { X }`, `export type * from '...'`) never
+occupies the value space, whatever its target is. The flags come from the
+checker, so a re-export from an unresolvable module surfaces with the checker's
+fallback classification (a value of type `any`).
 
 ## Type Operators
 

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -45,8 +45,10 @@ both a value and a type, `interface X {}` merged with `const X: X` is both, and
 a namespace containing only types is neither a value nor a type, only a
 namespace. Renamed and re-exported aliases report the spaces of the declaration
 they resolve to, combined with any local declarations merged onto the alias. A
-type-only re-export (`export type { X }`, `export type * from '...'`) never
-occupies the value space, whatever its target is. The flags come from the
+type-only re-export (`export type { X }`, `export type * from '...'`,
+`export type * as N from '...'`) never occupies the value space, whatever its
+target is, though a module also reached by a plain `export *` still exports its
+values through that path. The flags come from the
 checker, so a re-export from an unresolvable module surfaces with the checker's
 fallback classification (a value of type `any`).
 

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -47,10 +47,11 @@ namespace. Renamed and re-exported aliases report the spaces of the declaration
 they resolve to, combined with any local declarations merged onto the alias. A
 type-only re-export (`export type { X }`, `export type * from '...'`,
 `export type * as N from '...'`) never occupies the value space, whatever its
-target is, though a module also reached by a plain `export *` still exports its
-values through that path. The flags come from the
-checker, so a re-export from an unresolvable module surfaces with the checker's
-fallback classification (a value of type `any`).
+target is. When the same file also star-exports that module without `type`, the
+values still arrive through that path; reachability through a further module's
+star export is not modelled. The flags come from the checker, so a re-export
+from an unresolvable module surfaces with the checker's fallback classification
+(a value of type `any`).
 
 ## Type Operators
 

--- a/src/models/export.ts
+++ b/src/models/export.ts
@@ -11,36 +11,53 @@ export interface ExtendsTypeInfo {
 	resolvedName?: string;
 }
 
+/**
+ * Which of TypeScript's declaration spaces an export occupies.
+ */
+export interface DeclarationSpaces {
+	/**
+	 * Whether the export occupies the value declaration space.
+	 *
+	 * For example, `export const x = 'x'`, functions, classes, and enums are
+	 * values, while `export type X = 'x'` and lone interfaces are not. Merged
+	 * declarations such as `interface X {}` + `const X: X` are values. A
+	 * type-only re-export (`export type { X }`, `export type * from '...'`)
+	 * never occupies the value space, whatever it refers to. Note that `const
+	 * enum` members are inlined by default (`preserveConstEnums: false`), so a
+	 * value export does not guarantee a runtime binding in the emitted output.
+	 */
+	isValue: boolean;
+	/**
+	 * Whether the export occupies the type declaration space, i.e. names a type.
+	 *
+	 * For example, type aliases, interfaces, classes, and enums are types,
+	 * while `export const x = 'x'` and plain functions are not.
+	 */
+	isType: boolean;
+	/**
+	 * Whether the export declares a namespace or module.
+	 *
+	 * For example, `export namespace N {}`, possibly merged with a function or
+	 * class of the same name. A namespace containing only types is neither a
+	 * value nor a type, only a namespace. Expando assignments
+	 * (`fn.extra = ...`) do not make an export a namespace.
+	 */
+	isNamespace: boolean;
+}
+
 export class ExportNode {
+	/** See {@link DeclarationSpaces.isValue}. */
+	public isValue: boolean;
+	/** See {@link DeclarationSpaces.isType}. */
+	public isType: boolean;
+	/** See {@link DeclarationSpaces.isNamespace}. */
+	public isNamespace: boolean;
+
 	constructor(
 		public name: string,
 		public type: AnyType,
 		public documentation: Documentation | undefined,
-		/**
-		 * Whether the export occupies TypeScript's value declaration space, i.e.
-		 * exists at runtime.
-		 *
-		 * For example, `export const x = 'x'`, functions, classes, and enums are
-		 * values, while `export type X = 'x'` and lone interfaces are not. Merged
-		 * declarations such as `interface X {}` + `const X: X` are values.
-		 */
-		public isValue: boolean,
-		/**
-		 * Whether the export occupies TypeScript's type declaration space, i.e.
-		 * names a type.
-		 *
-		 * For example, type aliases, interfaces, classes, and enums are types,
-		 * while `export const x = 'x'` and plain functions are not.
-		 */
-		public isType: boolean,
-		/**
-		 * Whether the export occupies TypeScript's namespace declaration space.
-		 *
-		 * For example, `export namespace N {}` declares a namespace, possibly
-		 * merged with a function or class of the same name. A namespace
-		 * containing only types is neither a value nor a type, only a namespace.
-		 */
-		public isNamespace: boolean,
+		declarationSpaces: DeclarationSpaces,
 		/**
 		 * The full original name when this export is a re-export with a different name.
 		 *
@@ -57,16 +74,18 @@ export class ExportNode {
 		 * This allows consumers to track type compatibility for inherited components.
 		 */
 		public extendsTypes?: ExtendsTypeInfo[],
-	) {}
+	) {
+		this.isValue = declarationSpaces.isValue;
+		this.isType = declarationSpaces.isType;
+		this.isNamespace = declarationSpaces.isNamespace;
+	}
 
 	withType(type: AnyType): ExportNode {
 		return new ExportNode(
 			this.name,
 			type,
 			this.documentation,
-			this.isValue,
-			this.isType,
-			this.isNamespace,
+			{ isValue: this.isValue, isType: this.isType, isNamespace: this.isNamespace },
 			this.reexportedFrom,
 			this.extendsTypes,
 		);

--- a/src/models/export.ts
+++ b/src/models/export.ts
@@ -26,14 +26,14 @@ export interface DeclarationSpaces {
 	 * enum` members are inlined by default (`preserveConstEnums: false`), so a
 	 * value export does not guarantee a runtime binding in the emitted output.
 	 */
-	isValue: boolean;
+	readonly isValue: boolean;
 	/**
 	 * Whether the export occupies the type declaration space, i.e. names a type.
 	 *
 	 * For example, type aliases, interfaces, classes, and enums are types,
 	 * while `export const x = 'x'` and plain functions are not.
 	 */
-	isType: boolean;
+	readonly isType: boolean;
 	/**
 	 * Whether the export declares a namespace or module.
 	 *
@@ -42,10 +42,10 @@ export interface DeclarationSpaces {
 	 * value nor a type, only a namespace. Expando assignments
 	 * (`fn.extra = ...`) do not make an export a namespace.
 	 */
-	isNamespace: boolean;
+	readonly isNamespace: boolean;
 }
 
-export class ExportNode {
+export class ExportNode implements DeclarationSpaces {
 	/** See {@link DeclarationSpaces.isValue}. */
 	public readonly isValue: boolean;
 	/** See {@link DeclarationSpaces.isType}. */

--- a/src/models/export.ts
+++ b/src/models/export.ts
@@ -17,6 +17,31 @@ export class ExportNode {
 		public type: AnyType,
 		public documentation: Documentation | undefined,
 		/**
+		 * Whether the export occupies TypeScript's value declaration space, i.e.
+		 * exists at runtime.
+		 *
+		 * For example, `export const x = 'x'`, functions, classes, and enums are
+		 * values, while `export type X = 'x'` and lone interfaces are not. Merged
+		 * declarations such as `interface X {}` + `const X: X` are values.
+		 */
+		public isValue: boolean,
+		/**
+		 * Whether the export occupies TypeScript's type declaration space, i.e.
+		 * names a type.
+		 *
+		 * For example, type aliases, interfaces, classes, and enums are types,
+		 * while `export const x = 'x'` and plain functions are not.
+		 */
+		public isType: boolean,
+		/**
+		 * Whether the export occupies TypeScript's namespace declaration space.
+		 *
+		 * For example, `export namespace N {}` declares a namespace, possibly
+		 * merged with a function or class of the same name. A namespace
+		 * containing only types is neither a value nor a type, only a namespace.
+		 */
+		public isNamespace: boolean,
+		/**
 		 * The full original name when this export is a re-export with a different name.
 		 *
 		 * For example, `export { DialogTrigger as Trigger }` would have
@@ -39,6 +64,9 @@ export class ExportNode {
 			this.name,
 			type,
 			this.documentation,
+			this.isValue,
+			this.isType,
+			this.isNamespace,
 			this.reexportedFrom,
 			this.extendsTypes,
 		);

--- a/src/models/export.ts
+++ b/src/models/export.ts
@@ -47,11 +47,11 @@ export interface DeclarationSpaces {
 
 export class ExportNode {
 	/** See {@link DeclarationSpaces.isValue}. */
-	public isValue: boolean;
+	public readonly isValue: boolean;
 	/** See {@link DeclarationSpaces.isType}. */
-	public isType: boolean;
+	public readonly isType: boolean;
 	/** See {@link DeclarationSpaces.isNamespace}. */
-	public isNamespace: boolean;
+	public readonly isNamespace: boolean;
 
 	constructor(
 		public name: string,
@@ -85,7 +85,7 @@ export class ExportNode {
 			this.name,
 			type,
 			this.documentation,
-			{ isValue: this.isValue, isType: this.isType, isNamespace: this.isNamespace },
+			this,
 			this.reexportedFrom,
 			this.extendsTypes,
 		);

--- a/src/parsers/exportDescriptors.ts
+++ b/src/parsers/exportDescriptors.ts
@@ -59,6 +59,11 @@ export interface ExportDescriptor {
 	typeNode?: ts.TypeNode;
 	/** Original exported name when the public descriptor is a renamed re-export. */
 	reexportedFrom?: string;
+	/**
+	 * Whether the export is type-only (`export type { X }`). A type-only export
+	 * re-exports only the type meaning of its target, never the runtime value.
+	 */
+	isTypeOnlyExport?: boolean;
 	/** Interface or class heritage metadata attached to the export. */
 	extendsTypes?: ExtendsTypeInfo[];
 }
@@ -205,6 +210,8 @@ function resolveExportSpecifierDescriptors(
 			typeResolutionOrder: getNextTypeResolutionOrder(resolutionState),
 			symbolScope,
 			reexportedFrom,
+			isTypeOnlyExport:
+				exportDeclaration.isTypeOnly || exportDeclaration.parent.parent.isTypeOnly || undefined,
 			typeNode:
 				targetTypeAlias &&
 				shouldPreserveTypeAliasNode(targetTypeAlias, reexportedFrom, context.includeExternalTypes)

--- a/src/parsers/exportDescriptors.ts
+++ b/src/parsers/exportDescriptors.ts
@@ -110,30 +110,29 @@ export function resolveExportDescriptors(
 				scope,
 			);
 
+			let descriptors: ExportDescriptor[] | undefined;
 			if (ts.isModuleDeclaration(exportDeclaration)) {
-				return asNonEmptyDescriptors(namespaceDescriptors);
-			}
-
-			if (ts.isNamespaceExport(exportDeclaration)) {
-				return resolveNamespaceExportDescriptors(exportSymbol, scope);
-			}
-
-			if (ts.isExportSpecifier(exportDeclaration)) {
-				return resolveExportSpecifierDescriptors(
+				descriptors = asNonEmptyDescriptors(namespaceDescriptors);
+			} else if (ts.isNamespaceExport(exportDeclaration)) {
+				descriptors = resolveNamespaceExportDescriptors(exportSymbol, scope);
+			} else if (ts.isExportSpecifier(exportDeclaration)) {
+				descriptors = resolveExportSpecifierDescriptors(
 					exportSymbol,
 					exportDeclaration,
 					scope,
 					namespaceDescriptors,
 				);
+			} else {
+				descriptors = withNamespaceDescriptors(
+					resolveDeclarationExportDescriptor(exportSymbol, exportDeclaration, scope),
+					namespaceDescriptors,
+				);
 			}
 
-			const mainDescriptor = resolveDeclarationExportDescriptor(
-				exportSymbol,
-				exportDeclaration,
-				scope,
-			);
-
-			return withNamespaceDescriptors(mainDescriptor, namespaceDescriptors);
+			// Whichever declaration form carried it here, a symbol reached through a
+			// type-only export site loses its runtime binding — as do the members of any
+			// namespace merged onto it.
+			return withTypeOnlyExport(descriptors, isTypeOnlyAliasChain(exportSymbol, context.checker));
 		} catch (error) {
 			if (!(error instanceof ParserError)) {
 				throw new ParserError(error, context.parsedSymbolStack);
@@ -162,15 +161,9 @@ function resolveNamespaceExportDescriptors(
 		return;
 	}
 
-	const descriptors = asNonEmptyDescriptors(
+	return asNonEmptyDescriptors(
 		resolveNamespaceMemberDescriptors(aliasedSymbol, exportSymbol.name, scope),
 	);
-
-	// `export type * as Name` is a type-only export site like any other, so nothing
-	// reached through it keeps a runtime binding.
-	return isTypeOnlyAliasChain(exportSymbol, scope.context.checker)
-		? descriptors?.map((descriptor) => ({ ...descriptor, isTypeOnlyExport: true }))
-		: descriptors;
 }
 
 /**
@@ -192,17 +185,9 @@ function resolveExportSpecifierDescriptors(
 	namespaceDescriptors: ExportDescriptor[],
 ): ExportDescriptor[] | undefined {
 	const { context, parentNamespaces, symbolScope, resolutionState } = scope;
-	// Read before the unresolved-target return below, so members of a merged namespace
-	// are masked even when the target itself cannot be resolved.
-	const isTypeOnlyExport = isTypeOnlyAliasChain(exportSymbol, context.checker);
-	const maskTypeOnly = (descriptors: ExportDescriptor[] | undefined) =>
-		isTypeOnlyExport
-			? descriptors?.map((descriptor) => ({ ...descriptor, isTypeOnlyExport: true }))
-			: descriptors;
-
 	const targetSymbol = resolveExportSpecifierTarget(exportSymbol, exportDeclaration, context);
 	if (!targetSymbol) {
-		return maskTypeOnly(withNamespaceDescriptors(undefined, namespaceDescriptors));
+		return withNamespaceDescriptors(undefined, namespaceDescriptors);
 	}
 
 	const targetNamespaceDescriptors = resolveMergedNamespaceDescriptors(
@@ -224,7 +209,6 @@ function resolveExportSpecifierDescriptors(
 			typeResolutionOrder: getNextTypeResolutionOrder(resolutionState),
 			symbolScope,
 			reexportedFrom,
-			isTypeOnlyExport,
 			typeNode:
 				targetTypeAlias &&
 				shouldPreserveTypeAliasNode(targetTypeAlias, reexportedFrom, context.includeExternalTypes)
@@ -234,9 +218,7 @@ function resolveExportSpecifierDescriptors(
 		[...namespaceDescriptors, ...targetNamespaceDescriptors],
 	);
 
-	// Members of a merged namespace cross the same type-only export site as
-	// their owner, so they lose their runtime binding with it.
-	return maskTypeOnly(descriptors);
+	return descriptors;
 }
 
 /**
@@ -713,6 +695,22 @@ function withNamespaceDescriptors(
  */
 function asNonEmptyDescriptors(descriptors: ExportDescriptor[]): ExportDescriptor[] | undefined {
 	return descriptors.length > 0 ? descriptors : undefined;
+}
+
+/**
+ * Marks every descriptor as crossing a type-only export site, which strips its runtime
+ * binding. Returns the list unchanged when the export site is not type-only.
+ *
+ * @param descriptors Descriptors produced for one export.
+ * @param isTypeOnlyExport Whether the export site is type-only.
+ */
+function withTypeOnlyExport(
+	descriptors: ExportDescriptor[] | undefined,
+	isTypeOnlyExport: boolean,
+): ExportDescriptor[] | undefined {
+	return isTypeOnlyExport
+		? descriptors?.map((descriptor) => ({ ...descriptor, isTypeOnlyExport: true }))
+		: descriptors;
 }
 
 /**

--- a/src/parsers/exportDescriptors.ts
+++ b/src/parsers/exportDescriptors.ts
@@ -162,9 +162,15 @@ function resolveNamespaceExportDescriptors(
 		return;
 	}
 
-	return asNonEmptyDescriptors(
+	const descriptors = asNonEmptyDescriptors(
 		resolveNamespaceMemberDescriptors(aliasedSymbol, exportSymbol.name, scope),
 	);
+
+	// `export type * as Name` is a type-only export site like any other, so nothing
+	// reached through it keeps a runtime binding.
+	return isTypeOnlyAliasChain(exportSymbol, scope.context.checker)
+		? descriptors?.map((descriptor) => ({ ...descriptor, isTypeOnlyExport: true }))
+		: descriptors;
 }
 
 /**
@@ -186,9 +192,17 @@ function resolveExportSpecifierDescriptors(
 	namespaceDescriptors: ExportDescriptor[],
 ): ExportDescriptor[] | undefined {
 	const { context, parentNamespaces, symbolScope, resolutionState } = scope;
+	// Read before the unresolved-target return below, so members of a merged namespace
+	// are masked even when the target itself cannot be resolved.
+	const isTypeOnlyExport = isTypeOnlyAliasChain(exportSymbol, context.checker);
+	const maskTypeOnly = (descriptors: ExportDescriptor[] | undefined) =>
+		isTypeOnlyExport
+			? descriptors?.map((descriptor) => ({ ...descriptor, isTypeOnlyExport: true }))
+			: descriptors;
+
 	const targetSymbol = resolveExportSpecifierTarget(exportSymbol, exportDeclaration, context);
 	if (!targetSymbol) {
-		return withNamespaceDescriptors(undefined, namespaceDescriptors);
+		return maskTypeOnly(withNamespaceDescriptors(undefined, namespaceDescriptors));
 	}
 
 	const targetNamespaceDescriptors = resolveMergedNamespaceDescriptors(
@@ -201,7 +215,6 @@ function resolveExportSpecifierDescriptors(
 		isReExport && targetSymbol.name !== exportSymbol.name ? targetSymbol.name : undefined;
 	const targetTypeAlias = findAliasedTypeAliasDeclaration(targetSymbol, context.checker);
 	const targetTypeNode = targetTypeAlias?.type;
-	const isTypeOnlyExport = isTypeOnlyAliasChain(exportSymbol, context.checker);
 	const descriptors = withNamespaceDescriptors(
 		{
 			name: exportSymbol.name,
@@ -223,9 +236,7 @@ function resolveExportSpecifierDescriptors(
 
 	// Members of a merged namespace cross the same type-only export site as
 	// their owner, so they lose their runtime binding with it.
-	return isTypeOnlyExport
-		? descriptors?.map((descriptor) => ({ ...descriptor, isTypeOnlyExport: true }))
-		: descriptors;
+	return maskTypeOnly(descriptors);
 }
 
 /**

--- a/src/parsers/exportDescriptors.ts
+++ b/src/parsers/exportDescriptors.ts
@@ -210,8 +210,7 @@ function resolveExportSpecifierDescriptors(
 			typeResolutionOrder: getNextTypeResolutionOrder(resolutionState),
 			symbolScope,
 			reexportedFrom,
-			isTypeOnlyExport:
-				exportDeclaration.isTypeOnly || exportDeclaration.parent.parent.isTypeOnly || undefined,
+			isTypeOnlyExport: ts.isTypeOnlyExportDeclaration(exportDeclaration),
 			typeNode:
 				targetTypeAlias &&
 				shouldPreserveTypeAliasNode(targetTypeAlias, reexportedFrom, context.includeExternalTypes)

--- a/src/parsers/exportDescriptors.ts
+++ b/src/parsers/exportDescriptors.ts
@@ -201,7 +201,8 @@ function resolveExportSpecifierDescriptors(
 		isReExport && targetSymbol.name !== exportSymbol.name ? targetSymbol.name : undefined;
 	const targetTypeAlias = findAliasedTypeAliasDeclaration(targetSymbol, context.checker);
 	const targetTypeNode = targetTypeAlias?.type;
-	return withNamespaceDescriptors(
+	const isTypeOnlyExport = isTypeOnlyAliasChain(exportSymbol, context.checker);
+	const descriptors = withNamespaceDescriptors(
 		{
 			name: exportSymbol.name,
 			symbol: targetSymbol,
@@ -210,7 +211,7 @@ function resolveExportSpecifierDescriptors(
 			typeResolutionOrder: getNextTypeResolutionOrder(resolutionState),
 			symbolScope,
 			reexportedFrom,
-			isTypeOnlyExport: ts.isTypeOnlyExportDeclaration(exportDeclaration),
+			isTypeOnlyExport,
 			typeNode:
 				targetTypeAlias &&
 				shouldPreserveTypeAliasNode(targetTypeAlias, reexportedFrom, context.includeExternalTypes)
@@ -219,6 +220,31 @@ function resolveExportSpecifierDescriptors(
 		},
 		[...namespaceDescriptors, ...targetNamespaceDescriptors],
 	);
+
+	// Members of a merged namespace cross the same type-only export site as
+	// their owner, so they lose their runtime binding with it.
+	return isTypeOnlyExport
+		? descriptors?.map((descriptor) => ({ ...descriptor, isTypeOnlyExport: true }))
+		: descriptors;
+}
+
+/**
+ * Whether the export symbol's alias chain crosses a type-only import or export
+ * declaration (`export type { X }`, or a re-exported `import type { X }`). A
+ * type-only site strips the runtime value from everything exported through it,
+ * which resolving the alias chain in one jump would not see.
+ */
+function isTypeOnlyAliasChain(exportSymbol: ts.Symbol, checker: ts.TypeChecker): boolean {
+	const seen = new Set<ts.Symbol>();
+	let current: ts.Symbol | undefined = exportSymbol;
+	while (current && current.flags & ts.SymbolFlags.Alias && !seen.has(current)) {
+		seen.add(current);
+		if (current.declarations?.some(ts.isTypeOnlyImportOrExportDeclaration)) {
+			return true;
+		}
+		current = checker.getImmediateAliasedSymbol(current);
+	}
+	return false;
 }
 
 function shouldPreserveTypeAliasNode(

--- a/src/parsers/exportParser.ts
+++ b/src/parsers/exportParser.ts
@@ -23,6 +23,7 @@ export function parseExport(
 	exportSymbol: ts.Symbol,
 	parserContext: ScopedParserContext,
 	parentNamespaces: string[] = [],
+	isTypeOnlyExport = false,
 ): ExportNode[] | undefined {
 	const descriptors = resolveExportDescriptors(exportSymbol, parserContext, parentNamespaces);
 	if (!descriptors) {
@@ -31,7 +32,10 @@ export function parseExport(
 
 	const nodesByDescriptor = new Map<ExportDescriptor, ExportNode[] | undefined>();
 	for (const descriptor of getTypeResolutionOrderedDescriptors(descriptors)) {
-		nodesByDescriptor.set(descriptor, createExportNodesFromDescriptor(descriptor, parserContext));
+		nodesByDescriptor.set(
+			descriptor,
+			createExportNodesFromDescriptor(descriptor, parserContext, isTypeOnlyExport),
+		);
 	}
 
 	// Descriptor order is the emitted API order. Type-resolution order is kept
@@ -64,6 +68,7 @@ function getTypeResolutionOrderedDescriptors(descriptors: ExportDescriptor[]): E
 function createExportNodesFromDescriptor(
 	descriptor: ExportDescriptor,
 	parserContext: ScopedParserContext,
+	isTypeOnlyExport: boolean,
 ): ExportNode[] | undefined {
 	return runWithSymbolScopes(parserContext, descriptor.symbolScope, () => {
 		try {
@@ -82,9 +87,10 @@ function createExportNodesFromDescriptor(
 						: descriptor.name;
 
 				const declarationSpaces = getDeclarationSpaces(descriptor.symbol, parserContext.checker);
-				if (descriptor.isTypeOnlyExport) {
-					// A type-only export re-exports only the type meaning of its target;
-					// the runtime value does not cross the export site.
+				if (descriptor.isTypeOnlyExport || isTypeOnlyExport) {
+					// A type-only export (`export type { X }`, `export type * from`)
+					// re-exports only the type meaning of its target; the runtime value
+					// does not cross the export site.
 					declarationSpaces.isValue = false;
 				}
 
@@ -110,27 +116,28 @@ function createExportNodesFromDescriptor(
 }
 
 /**
- * Determines which of TypeScript's declaration spaces an export occupies.
+ * Determines which declaration spaces an export occupies. See
+ * {@link DeclarationSpaces} for the semantics.
  *
- * Example: `export const x = 'x'` is a value, `export type X = 'x'` is a type,
- * and a class or a merged `interface X {}` + `const X: X` declaration is both.
- * A namespace containing only types occupies just the namespace space. Alias
- * symbols (re-exported imports) resolve to their targets, keeping the alias
- * symbol's own flags too: an alias merged with a local declaration occupies
- * the spaces of both. Namespaces are recognized by an actual namespace or
- * module declaration rather than `SymbolFlags.Module`, because the binder also
- * sets that flag for expando assignments (`fn.extra = ...`).
+ * Alias symbols (re-exported imports) resolve to their targets, keeping the
+ * alias symbol's own flags too: an alias merged with a local declaration
+ * occupies the spaces of both. Namespaces are recognized by an actual
+ * namespace or module declaration rather than `SymbolFlags.Module`, because
+ * the binder also sets that flag for expando assignments (`fn.extra = ...`).
  */
 function getDeclarationSpaces(symbol: ts.Symbol, checker: ts.TypeChecker): DeclarationSpaces {
 	const resolvedSymbol =
 		symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol;
 	const flags = symbol.flags | resolvedSymbol.flags;
-	const declarations = [...(symbol.declarations ?? []), ...(resolvedSymbol.declarations ?? [])];
+	const hasNamespaceDeclaration = (candidate: ts.Symbol) =>
+		candidate.declarations?.some(ts.isModuleDeclaration) ?? false;
 
 	return {
 		isValue: (flags & ts.SymbolFlags.Value) !== 0,
 		isType: (flags & ts.SymbolFlags.Type) !== 0,
-		isNamespace: declarations.some(ts.isModuleDeclaration),
+		isNamespace:
+			hasNamespaceDeclaration(symbol) ||
+			(resolvedSymbol !== symbol && hasNamespaceDeclaration(resolvedSymbol)),
 	};
 }
 

--- a/src/parsers/exportParser.ts
+++ b/src/parsers/exportParser.ts
@@ -86,12 +86,12 @@ function createExportNodesFromDescriptor(
 						? [...descriptor.parentNamespaces, descriptor.name].join('.')
 						: descriptor.name;
 
-				const declarationSpaces = getDeclarationSpaces(descriptor.symbol, parserContext.checker);
+				let declarationSpaces = getDeclarationSpaces(descriptor.symbol, parserContext.checker);
 				if (descriptor.isTypeOnlyExport || isTypeOnlyExport) {
 					// A type-only export (`export type { X }`, `export type * from`)
 					// re-exports only the type meaning of its target; the runtime value
 					// does not cross the export site.
-					declarationSpaces.isValue = false;
+					declarationSpaces = { ...declarationSpaces, isValue: false };
 				}
 
 				return [
@@ -135,9 +135,7 @@ function getDeclarationSpaces(symbol: ts.Symbol, checker: ts.TypeChecker): Decla
 	return {
 		isValue: (flags & ts.SymbolFlags.Value) !== 0,
 		isType: (flags & ts.SymbolFlags.Type) !== 0,
-		isNamespace:
-			hasNamespaceDeclaration(symbol) ||
-			(resolvedSymbol !== symbol && hasNamespaceDeclaration(resolvedSymbol)),
+		isNamespace: hasNamespaceDeclaration(symbol) || hasNamespaceDeclaration(resolvedSymbol),
 	};
 }
 

--- a/src/parsers/exportParser.ts
+++ b/src/parsers/exportParser.ts
@@ -75,11 +75,16 @@ function createExportNodesFromDescriptor(
 						? [...descriptor.parentNamespaces, descriptor.name].join('.')
 						: descriptor.name;
 
+				const declarationSpaces = getDeclarationSpaces(descriptor.symbol, parserContext.checker);
+
 				return [
 					new ExportNode(
 						exportName,
 						parsedType,
 						getDocumentationFromSymbol(descriptor.symbol, parserContext.checker),
+						declarationSpaces.isValue,
+						declarationSpaces.isType,
+						declarationSpaces.isNamespace,
 						descriptor.reexportedFrom,
 						descriptor.extendsTypes,
 					),
@@ -93,6 +98,29 @@ function createExportNodesFromDescriptor(
 			throw error;
 		}
 	});
+}
+
+/**
+ * Determines which of TypeScript's declaration spaces an export occupies.
+ *
+ * Example: `export const x = 'x'` is a value, `export type X = 'x'` is a type,
+ * and a class or a merged `interface X {}` + `const X: X` declaration is both.
+ * A namespace containing only types occupies just the namespace space. Alias
+ * symbols (re-exported imports) are resolved to their targets first so the
+ * flags reflect the original declaration.
+ */
+function getDeclarationSpaces(
+	symbol: ts.Symbol,
+	checker: ts.TypeChecker,
+): { isValue: boolean; isType: boolean; isNamespace: boolean } {
+	const resolvedSymbol =
+		symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol;
+
+	return {
+		isValue: (resolvedSymbol.flags & ts.SymbolFlags.Value) !== 0,
+		isType: (resolvedSymbol.flags & ts.SymbolFlags.Type) !== 0,
+		isNamespace: (resolvedSymbol.flags & ts.SymbolFlags.Module) !== 0,
+	};
 }
 
 /**

--- a/src/parsers/exportParser.ts
+++ b/src/parsers/exportParser.ts
@@ -1,5 +1,11 @@
 import ts from 'typescript';
-import { ExportNode, TypeName, withTypeName, type AnyType } from '../models';
+import {
+	ExportNode,
+	TypeName,
+	withTypeName,
+	type AnyType,
+	type DeclarationSpaces,
+} from '../models';
 import { ParserError } from '../ParserError';
 import { type ScopedParserContext } from '../parserContext';
 import { isInternalSymbolName } from './common';
@@ -76,15 +82,18 @@ function createExportNodesFromDescriptor(
 						: descriptor.name;
 
 				const declarationSpaces = getDeclarationSpaces(descriptor.symbol, parserContext.checker);
+				if (descriptor.isTypeOnlyExport) {
+					// A type-only export re-exports only the type meaning of its target;
+					// the runtime value does not cross the export site.
+					declarationSpaces.isValue = false;
+				}
 
 				return [
 					new ExportNode(
 						exportName,
 						parsedType,
 						getDocumentationFromSymbol(descriptor.symbol, parserContext.checker),
-						declarationSpaces.isValue,
-						declarationSpaces.isType,
-						declarationSpaces.isNamespace,
+						declarationSpaces,
 						descriptor.reexportedFrom,
 						descriptor.extendsTypes,
 					),
@@ -106,20 +115,22 @@ function createExportNodesFromDescriptor(
  * Example: `export const x = 'x'` is a value, `export type X = 'x'` is a type,
  * and a class or a merged `interface X {}` + `const X: X` declaration is both.
  * A namespace containing only types occupies just the namespace space. Alias
- * symbols (re-exported imports) are resolved to their targets first so the
- * flags reflect the original declaration.
+ * symbols (re-exported imports) resolve to their targets, keeping the alias
+ * symbol's own flags too: an alias merged with a local declaration occupies
+ * the spaces of both. Namespaces are recognized by an actual namespace or
+ * module declaration rather than `SymbolFlags.Module`, because the binder also
+ * sets that flag for expando assignments (`fn.extra = ...`).
  */
-function getDeclarationSpaces(
-	symbol: ts.Symbol,
-	checker: ts.TypeChecker,
-): { isValue: boolean; isType: boolean; isNamespace: boolean } {
+function getDeclarationSpaces(symbol: ts.Symbol, checker: ts.TypeChecker): DeclarationSpaces {
 	const resolvedSymbol =
 		symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol;
+	const flags = symbol.flags | resolvedSymbol.flags;
+	const declarations = [...(symbol.declarations ?? []), ...(resolvedSymbol.declarations ?? [])];
 
 	return {
-		isValue: (resolvedSymbol.flags & ts.SymbolFlags.Value) !== 0,
-		isType: (resolvedSymbol.flags & ts.SymbolFlags.Type) !== 0,
-		isNamespace: (resolvedSymbol.flags & ts.SymbolFlags.Module) !== 0,
+		isValue: (flags & ts.SymbolFlags.Value) !== 0,
+		isType: (flags & ts.SymbolFlags.Type) !== 0,
+		isNamespace: declarations.some(ts.isModuleDeclaration),
 	};
 }
 

--- a/src/parsers/exportTransforms.test.ts
+++ b/src/parsers/exportTransforms.test.ts
@@ -52,8 +52,16 @@ function createFunctionNode(
 }
 
 it('classifies component exports separately from export transformation', () => {
-	expect(isComponentExport(new ExportNode('Button', createFunctionNode(), undefined))).toBe(true);
-	expect(isComponentExport(new ExportNode('default', createFunctionNode(), undefined))).toBe(true);
+	expect(
+		isComponentExport(
+			new ExportNode('Button', createFunctionNode(), undefined, true, false, false),
+		),
+	).toBe(true);
+	expect(
+		isComponentExport(
+			new ExportNode('default', createFunctionNode(), undefined, true, false, false),
+		),
+	).toBe(true);
 	expect(
 		isComponentExport(
 			new ExportNode(
@@ -65,13 +73,27 @@ it('classifies component exports separately from export transformation', () => {
 					]),
 				),
 				undefined,
+				true,
+				false,
+				false,
 			),
 		),
 	).toBe(true);
-	expect(isComponentExport(new ExportNode('button', createFunctionNode(), undefined))).toBe(false);
 	expect(
 		isComponentExport(
-			new ExportNode('Button', createFunctionNode(new IntrinsicNode('string')), undefined),
+			new ExportNode('button', createFunctionNode(), undefined, true, false, false),
+		),
+	).toBe(false);
+	expect(
+		isComponentExport(
+			new ExportNode(
+				'Button',
+				createFunctionNode(new IntrinsicNode('string')),
+				undefined,
+				true,
+				false,
+				false,
+			),
 		),
 	).toBe(false);
 });
@@ -82,7 +104,9 @@ it('classifies a union of component-like functions as a component export', () =>
 		createFunctionNode(undefined, 'ToolbarWithRender', ['render']),
 	]);
 
-	expect(isComponentExport(new ExportNode('Toolbar', componentUnion, undefined))).toBe(true);
+	expect(
+		isComponentExport(new ExportNode('Toolbar', componentUnion, undefined, true, false, false)),
+	).toBe(true);
 });
 
 it('keeps unions with a non-component member out of the component classification', () => {
@@ -91,7 +115,9 @@ it('keeps unions with a non-component member out of the component classification
 		new IntrinsicNode('undefined'),
 	]);
 
-	expect(isComponentExport(new ExportNode('Toolbar', partialUnion, undefined))).toBe(false);
+	expect(
+		isComponentExport(new ExportNode('Toolbar', partialUnion, undefined, true, false, false)),
+	).toBe(false);
 });
 
 it('merges the props of every union member into one component', () => {
@@ -99,7 +125,7 @@ it('merges the props of every union member into one component', () => {
 		createFunctionNode(undefined, 'ToolbarRoot', ['children', 'className']),
 		createFunctionNode(undefined, 'ToolbarWithRender', ['render', 'className']),
 	]);
-	const exportNode = new ExportNode('Toolbar', componentUnion, undefined);
+	const exportNode = new ExportNode('Toolbar', componentUnion, undefined, true, false, false);
 
 	const componentNode = applyExportTransforms([exportNode], parserContext)[0]!
 		.type as ComponentNode;
@@ -125,7 +151,7 @@ it('marks props as optional when a union member accepts no props', () => {
 		createFunctionNode(undefined, 'ToolbarStandalone', []),
 		createFunctionNode(undefined, 'ToolbarWithProps', ['id']),
 	]);
-	const exportNode = new ExportNode('Toolbar', componentUnion, undefined);
+	const exportNode = new ExportNode('Toolbar', componentUnion, undefined, true, false, false);
 
 	const componentNode = applyExportTransforms([exportNode], parserContext)[0]!
 		.type as ComponentNode;
@@ -141,7 +167,7 @@ it('keeps the shared type name when every union member agrees on it', () => {
 		createFunctionNode(undefined, 'Toolbar', ['children']),
 		createFunctionNode(undefined, 'Toolbar', ['render']),
 	]);
-	const exportNode = new ExportNode('Toolbar', componentUnion, undefined);
+	const exportNode = new ExportNode('Toolbar', componentUnion, undefined, true, false, false);
 
 	const componentNode = applyExportTransforms([exportNode], parserContext)[0]!
 		.type as ComponentNode;
@@ -156,6 +182,9 @@ it('applies component transforms without losing export metadata', () => {
 		'Button',
 		createFunctionNode(),
 		documentation,
+		true,
+		false,
+		false,
 		'InternalButton',
 		extendsTypes,
 	);
@@ -168,10 +197,13 @@ it('applies component transforms without losing export metadata', () => {
 	expect(transformedNode.documentation).toBe(documentation);
 	expect(transformedNode.reexportedFrom).toBe('InternalButton');
 	expect(transformedNode.extendsTypes).toBe(extendsTypes);
+	expect(transformedNode.isValue).toBe(true);
+	expect(transformedNode.isType).toBe(false);
+	expect(transformedNode.isNamespace).toBe(false);
 });
 
 it('keeps non-component exports unchanged', () => {
-	const exportNode = new ExportNode('button', createFunctionNode(), undefined);
+	const exportNode = new ExportNode('button', createFunctionNode(), undefined, true, false, false);
 
 	expect(applyExportTransforms([exportNode], parserContext)[0]).toBe(exportNode);
 });

--- a/src/parsers/exportTransforms.test.ts
+++ b/src/parsers/exportTransforms.test.ts
@@ -26,6 +26,10 @@ const parserContext = {
 
 const valueSpaces: DeclarationSpaces = { isValue: true, isType: false, isNamespace: false };
 
+function createValueExport(name: string, type: AnyType): ExportNode {
+	return new ExportNode(name, type, undefined, valueSpaces);
+}
+
 it('keeps typeOperatorOutput optional on the public parser context', () => {
 	expectTypeOf({}).toMatchTypeOf<Pick<ParserContext, 'typeOperatorOutput'>>();
 });
@@ -55,15 +59,11 @@ function createFunctionNode(
 }
 
 it('classifies component exports separately from export transformation', () => {
-	expect(
-		isComponentExport(new ExportNode('Button', createFunctionNode(), undefined, valueSpaces)),
-	).toBe(true);
-	expect(
-		isComponentExport(new ExportNode('default', createFunctionNode(), undefined, valueSpaces)),
-	).toBe(true);
+	expect(isComponentExport(createValueExport('Button', createFunctionNode()))).toBe(true);
+	expect(isComponentExport(createValueExport('default', createFunctionNode()))).toBe(true);
 	expect(
 		isComponentExport(
-			new ExportNode(
+			createValueExport(
 				'Button',
 				createFunctionNode(
 					new UnionNode(undefined, [
@@ -71,23 +71,12 @@ it('classifies component exports separately from export transformation', () => {
 						new ExternalTypeNode(new TypeName('ReactNode')),
 					]),
 				),
-				undefined,
-				valueSpaces,
 			),
 		),
 	).toBe(true);
+	expect(isComponentExport(createValueExport('button', createFunctionNode()))).toBe(false);
 	expect(
-		isComponentExport(new ExportNode('button', createFunctionNode(), undefined, valueSpaces)),
-	).toBe(false);
-	expect(
-		isComponentExport(
-			new ExportNode(
-				'Button',
-				createFunctionNode(new IntrinsicNode('string')),
-				undefined,
-				valueSpaces,
-			),
-		),
+		isComponentExport(createValueExport('Button', createFunctionNode(new IntrinsicNode('string')))),
 	).toBe(false);
 });
 
@@ -97,9 +86,7 @@ it('classifies a union of component-like functions as a component export', () =>
 		createFunctionNode(undefined, 'ToolbarWithRender', ['render']),
 	]);
 
-	expect(isComponentExport(new ExportNode('Toolbar', componentUnion, undefined, valueSpaces))).toBe(
-		true,
-	);
+	expect(isComponentExport(createValueExport('Toolbar', componentUnion))).toBe(true);
 });
 
 it('keeps unions with a non-component member out of the component classification', () => {
@@ -108,9 +95,7 @@ it('keeps unions with a non-component member out of the component classification
 		new IntrinsicNode('undefined'),
 	]);
 
-	expect(isComponentExport(new ExportNode('Toolbar', partialUnion, undefined, valueSpaces))).toBe(
-		false,
-	);
+	expect(isComponentExport(createValueExport('Toolbar', partialUnion))).toBe(false);
 });
 
 it('merges the props of every union member into one component', () => {
@@ -118,7 +103,7 @@ it('merges the props of every union member into one component', () => {
 		createFunctionNode(undefined, 'ToolbarRoot', ['children', 'className']),
 		createFunctionNode(undefined, 'ToolbarWithRender', ['render', 'className']),
 	]);
-	const exportNode = new ExportNode('Toolbar', componentUnion, undefined, valueSpaces);
+	const exportNode = createValueExport('Toolbar', componentUnion);
 
 	const componentNode = applyExportTransforms([exportNode], parserContext)[0]!
 		.type as ComponentNode;
@@ -144,7 +129,7 @@ it('marks props as optional when a union member accepts no props', () => {
 		createFunctionNode(undefined, 'ToolbarStandalone', []),
 		createFunctionNode(undefined, 'ToolbarWithProps', ['id']),
 	]);
-	const exportNode = new ExportNode('Toolbar', componentUnion, undefined, valueSpaces);
+	const exportNode = createValueExport('Toolbar', componentUnion);
 
 	const componentNode = applyExportTransforms([exportNode], parserContext)[0]!
 		.type as ComponentNode;
@@ -160,7 +145,7 @@ it('keeps the shared type name when every union member agrees on it', () => {
 		createFunctionNode(undefined, 'Toolbar', ['children']),
 		createFunctionNode(undefined, 'Toolbar', ['render']),
 	]);
-	const exportNode = new ExportNode('Toolbar', componentUnion, undefined, valueSpaces);
+	const exportNode = createValueExport('Toolbar', componentUnion);
 
 	const componentNode = applyExportTransforms([exportNode], parserContext)[0]!
 		.type as ComponentNode;
@@ -194,7 +179,7 @@ it('applies component transforms without losing export metadata', () => {
 });
 
 it('keeps non-component exports unchanged', () => {
-	const exportNode = new ExportNode('button', createFunctionNode(), undefined, valueSpaces);
+	const exportNode = createValueExport('button', createFunctionNode());
 
 	expect(applyExportTransforms([exportNode], parserContext)[0]).toBe(exportNode);
 });

--- a/src/parsers/exportTransforms.test.ts
+++ b/src/parsers/exportTransforms.test.ts
@@ -13,6 +13,7 @@ import {
 	TypeName,
 	UnionNode,
 	type AnyType,
+	type DeclarationSpaces,
 	type ExtendsTypeInfo,
 	type ParserContext,
 } from '../index';
@@ -22,6 +23,8 @@ import { applyExportTransforms } from './exportTransforms';
 const parserContext = {
 	compilerOptions: {},
 } as ParserContext;
+
+const valueSpaces: DeclarationSpaces = { isValue: true, isType: false, isNamespace: false };
 
 it('keeps typeOperatorOutput optional on the public parser context', () => {
 	expectTypeOf({}).toMatchTypeOf<Pick<ParserContext, 'typeOperatorOutput'>>();
@@ -53,14 +56,10 @@ function createFunctionNode(
 
 it('classifies component exports separately from export transformation', () => {
 	expect(
-		isComponentExport(
-			new ExportNode('Button', createFunctionNode(), undefined, true, false, false),
-		),
+		isComponentExport(new ExportNode('Button', createFunctionNode(), undefined, valueSpaces)),
 	).toBe(true);
 	expect(
-		isComponentExport(
-			new ExportNode('default', createFunctionNode(), undefined, true, false, false),
-		),
+		isComponentExport(new ExportNode('default', createFunctionNode(), undefined, valueSpaces)),
 	).toBe(true);
 	expect(
 		isComponentExport(
@@ -73,16 +72,12 @@ it('classifies component exports separately from export transformation', () => {
 					]),
 				),
 				undefined,
-				true,
-				false,
-				false,
+				valueSpaces,
 			),
 		),
 	).toBe(true);
 	expect(
-		isComponentExport(
-			new ExportNode('button', createFunctionNode(), undefined, true, false, false),
-		),
+		isComponentExport(new ExportNode('button', createFunctionNode(), undefined, valueSpaces)),
 	).toBe(false);
 	expect(
 		isComponentExport(
@@ -90,9 +85,7 @@ it('classifies component exports separately from export transformation', () => {
 				'Button',
 				createFunctionNode(new IntrinsicNode('string')),
 				undefined,
-				true,
-				false,
-				false,
+				valueSpaces,
 			),
 		),
 	).toBe(false);
@@ -104,9 +97,9 @@ it('classifies a union of component-like functions as a component export', () =>
 		createFunctionNode(undefined, 'ToolbarWithRender', ['render']),
 	]);
 
-	expect(
-		isComponentExport(new ExportNode('Toolbar', componentUnion, undefined, true, false, false)),
-	).toBe(true);
+	expect(isComponentExport(new ExportNode('Toolbar', componentUnion, undefined, valueSpaces))).toBe(
+		true,
+	);
 });
 
 it('keeps unions with a non-component member out of the component classification', () => {
@@ -115,9 +108,9 @@ it('keeps unions with a non-component member out of the component classification
 		new IntrinsicNode('undefined'),
 	]);
 
-	expect(
-		isComponentExport(new ExportNode('Toolbar', partialUnion, undefined, true, false, false)),
-	).toBe(false);
+	expect(isComponentExport(new ExportNode('Toolbar', partialUnion, undefined, valueSpaces))).toBe(
+		false,
+	);
 });
 
 it('merges the props of every union member into one component', () => {
@@ -125,7 +118,7 @@ it('merges the props of every union member into one component', () => {
 		createFunctionNode(undefined, 'ToolbarRoot', ['children', 'className']),
 		createFunctionNode(undefined, 'ToolbarWithRender', ['render', 'className']),
 	]);
-	const exportNode = new ExportNode('Toolbar', componentUnion, undefined, true, false, false);
+	const exportNode = new ExportNode('Toolbar', componentUnion, undefined, valueSpaces);
 
 	const componentNode = applyExportTransforms([exportNode], parserContext)[0]!
 		.type as ComponentNode;
@@ -151,7 +144,7 @@ it('marks props as optional when a union member accepts no props', () => {
 		createFunctionNode(undefined, 'ToolbarStandalone', []),
 		createFunctionNode(undefined, 'ToolbarWithProps', ['id']),
 	]);
-	const exportNode = new ExportNode('Toolbar', componentUnion, undefined, true, false, false);
+	const exportNode = new ExportNode('Toolbar', componentUnion, undefined, valueSpaces);
 
 	const componentNode = applyExportTransforms([exportNode], parserContext)[0]!
 		.type as ComponentNode;
@@ -167,7 +160,7 @@ it('keeps the shared type name when every union member agrees on it', () => {
 		createFunctionNode(undefined, 'Toolbar', ['children']),
 		createFunctionNode(undefined, 'Toolbar', ['render']),
 	]);
-	const exportNode = new ExportNode('Toolbar', componentUnion, undefined, true, false, false);
+	const exportNode = new ExportNode('Toolbar', componentUnion, undefined, valueSpaces);
 
 	const componentNode = applyExportTransforms([exportNode], parserContext)[0]!
 		.type as ComponentNode;
@@ -182,9 +175,7 @@ it('applies component transforms without losing export metadata', () => {
 		'Button',
 		createFunctionNode(),
 		documentation,
-		true,
-		false,
-		false,
+		valueSpaces,
 		'InternalButton',
 		extendsTypes,
 	);
@@ -203,7 +194,7 @@ it('applies component transforms without losing export metadata', () => {
 });
 
 it('keeps non-component exports unchanged', () => {
-	const exportNode = new ExportNode('button', createFunctionNode(), undefined, true, false, false);
+	const exportNode = new ExportNode('button', createFunctionNode(), undefined, valueSpaces);
 
 	expect(applyExportTransforms([exportNode], parserContext)[0]).toBe(exportNode);
 });

--- a/src/parsers/moduleParser.ts
+++ b/src/parsers/moduleParser.ts
@@ -37,16 +37,19 @@ function isPureType(symbol: ts.Symbol): boolean {
 }
 
 /**
- * Builds the sets of module specifiers re-exported with `export *`, split by whether the
- * re-export is type-only. A type-only star export contributes only the module's type
- * exports; a plain one contributes its values too.
+ * Source files re-exported with `export type *`, whose exports should therefore contribute
+ * only their types. A module also reached by a plain `export *` is excluded: that path
+ * still carries the values, so the type-only re-export has nothing to take away.
+ *
+ * Only star exports written in this file are considered. A value path reaching the same
+ * module through another module's star export is not modelled.
  */
-function getStarExportModules(sourceFile: ts.SourceFile): {
-	typeOnly: Set<string>;
-	value: Set<string>;
-} {
-	const typeOnly = new Set<string>();
-	const value = new Set<string>();
+function getTypeOnlyStarExportSourceFiles(
+	sourceFile: ts.SourceFile,
+	program: ts.Program,
+): Set<ts.SourceFile> {
+	const typeOnlySpecifiers = new Set<string>();
+	const valueSpecifiers = new Set<string>();
 
 	for (const statement of sourceFile.statements) {
 		if (
@@ -55,12 +58,35 @@ function getStarExportModules(sourceFile: ts.SourceFile): {
 			statement.moduleSpecifier &&
 			ts.isStringLiteral(statement.moduleSpecifier)
 		) {
-			const modules = statement.isTypeOnly ? typeOnly : value;
-			modules.add(statement.moduleSpecifier.text);
+			const specifiers = statement.isTypeOnly ? typeOnlySpecifiers : valueSpecifiers;
+			specifiers.add(statement.moduleSpecifier.text);
 		}
 	}
 
-	return { typeOnly, value };
+	const typeOnlySourceFiles = new Set<ts.SourceFile>();
+	if (typeOnlySpecifiers.size === 0) {
+		// Nothing to mask, so the value specifiers are not worth resolving.
+		return typeOnlySourceFiles;
+	}
+
+	// Resolve rather than compare specifiers, so two spellings of one module are recognized
+	// as the same file.
+	const valueSourceFiles = new Set<ts.SourceFile>();
+	for (const specifier of valueSpecifiers) {
+		const resolved = resolveModuleSpecifier(specifier, sourceFile.fileName, program);
+		if (resolved) {
+			valueSourceFiles.add(resolved);
+		}
+	}
+
+	for (const specifier of typeOnlySpecifiers) {
+		const resolved = resolveModuleSpecifier(specifier, sourceFile.fileName, program);
+		if (resolved && !valueSourceFiles.has(resolved)) {
+			typeOnlySourceFiles.add(resolved);
+		}
+	}
+
+	return typeOnlySourceFiles;
 }
 
 /**
@@ -99,30 +125,7 @@ export function parseModule(sourceFile: ts.SourceFile, context: ScopedParserCont
 				throw new Error('Failed to get the source file symbol');
 			}
 
-			// Find modules that are re-exported with `export *`, type-only or not
-			const starExportModules = getStarExportModules(sourceFile);
-			const program = context.program;
-
-			// Resolve to source files rather than compare specifiers, so two spellings of
-			// the same module are recognized as one.
-			const valueStarSourceFiles = new Set<ts.SourceFile>();
-			for (const moduleSpecifier of starExportModules.value) {
-				const resolved = resolveModuleSpecifier(moduleSpecifier, sourceFile.fileName, program);
-				if (resolved) {
-					valueStarSourceFiles.add(resolved);
-				}
-			}
-
-			// Build a set of source files that correspond to type-only star exports
-			const typeOnlySourceFiles = new Set<ts.SourceFile>();
-			for (const moduleSpecifier of starExportModules.typeOnly) {
-				const resolved = resolveModuleSpecifier(moduleSpecifier, sourceFile.fileName, program);
-				// A module also reached by a plain `export *` still exports its values, so the
-				// type-only re-export adds nothing to take away.
-				if (resolved && !valueStarSourceFiles.has(resolved)) {
-					typeOnlySourceFiles.add(resolved);
-				}
-			}
+			const typeOnlySourceFiles = getTypeOnlyStarExportSourceFiles(sourceFile, context.program);
 
 			let parsedModuleExports: ExportNode[] = [];
 			const exportedSymbols = checker.getExportsOfModule(sourceFileSymbol);

--- a/src/parsers/moduleParser.ts
+++ b/src/parsers/moduleParser.ts
@@ -37,25 +37,30 @@ function isPureType(symbol: ts.Symbol): boolean {
 }
 
 /**
- * Builds a set of module specifiers that are re-exported with `export type *`.
- * These modules should only have their type exports included, not values.
+ * Builds the sets of module specifiers re-exported with `export *`, split by whether the
+ * re-export is type-only. A type-only star export contributes only the module's type
+ * exports; a plain one contributes its values too.
  */
-function getTypeOnlyStarExportModules(sourceFile: ts.SourceFile): Set<string> {
-	const typeOnlyModules = new Set<string>();
+function getStarExportModules(sourceFile: ts.SourceFile): {
+	typeOnly: Set<string>;
+	value: Set<string>;
+} {
+	const typeOnly = new Set<string>();
+	const value = new Set<string>();
 
 	for (const statement of sourceFile.statements) {
 		if (
 			ts.isExportDeclaration(statement) &&
-			statement.isTypeOnly &&
 			!statement.exportClause && // Star export (no explicit exports listed)
 			statement.moduleSpecifier &&
 			ts.isStringLiteral(statement.moduleSpecifier)
 		) {
-			typeOnlyModules.add(statement.moduleSpecifier.text);
+			const modules = statement.isTypeOnly ? typeOnly : value;
+			modules.add(statement.moduleSpecifier.text);
 		}
 	}
 
-	return typeOnlyModules;
+	return { typeOnly, value };
 }
 
 /**
@@ -94,15 +99,27 @@ export function parseModule(sourceFile: ts.SourceFile, context: ScopedParserCont
 				throw new Error('Failed to get the source file symbol');
 			}
 
-			// Find modules that are re-exported with `export type *`
-			const typeOnlyStarExportModules = getTypeOnlyStarExportModules(sourceFile);
+			// Find modules that are re-exported with `export *`, type-only or not
+			const starExportModules = getStarExportModules(sourceFile);
+			const program = context.program;
+
+			// Resolve to source files rather than compare specifiers, so two spellings of
+			// the same module are recognized as one.
+			const valueStarSourceFiles = new Set<ts.SourceFile>();
+			for (const moduleSpecifier of starExportModules.value) {
+				const resolved = resolveModuleSpecifier(moduleSpecifier, sourceFile.fileName, program);
+				if (resolved) {
+					valueStarSourceFiles.add(resolved);
+				}
+			}
 
 			// Build a set of source files that correspond to type-only star exports
 			const typeOnlySourceFiles = new Set<ts.SourceFile>();
-			const program = context.program;
-			for (const moduleSpecifier of typeOnlyStarExportModules) {
+			for (const moduleSpecifier of starExportModules.typeOnly) {
 				const resolved = resolveModuleSpecifier(moduleSpecifier, sourceFile.fileName, program);
-				if (resolved) {
+				// A module also reached by a plain `export *` still exports its values, so the
+				// type-only re-export adds nothing to take away.
+				if (resolved && !valueStarSourceFiles.has(resolved)) {
 					typeOnlySourceFiles.add(resolved);
 				}
 			}

--- a/src/parsers/moduleParser.ts
+++ b/src/parsers/moduleParser.ts
@@ -114,9 +114,11 @@ export function parseModule(sourceFile: ts.SourceFile, context: ScopedParserCont
 				// Check if this symbol comes from a type-only star export module
 				// If so, skip it if it's not a pure type
 				const declarations = exportedSymbol.declarations;
+				let isTypeOnlyStarExport = false;
 				if (declarations && declarations.length > 0) {
 					const symbolSourceFile = declarations[0].getSourceFile();
-					if (typeOnlySourceFiles.has(symbolSourceFile) && !isPureType(exportedSymbol)) {
+					isTypeOnlyStarExport = typeOnlySourceFiles.has(symbolSourceFile);
+					if (isTypeOnlyStarExport && !isPureType(exportedSymbol)) {
 						// This is a value (like a function with merged namespace) from a type-only export
 						// Skip it - TypeScript doesn't actually export it
 						continue;
@@ -126,6 +128,14 @@ export function parseModule(sourceFile: ts.SourceFile, context: ScopedParserCont
 				const parsedExports = parseExport(exportedSymbol, context);
 				if (!parsedExports) {
 					continue;
+				}
+				if (isTypeOnlyStarExport) {
+					// The surviving pure types can include enums, which occupy the value
+					// space at their declaration - but `export type *` only re-exports
+					// their type meaning.
+					for (const parsedExport of parsedExports) {
+						parsedExport.isValue = false;
+					}
 				}
 				parsedModuleExports.push(...parsedExports);
 			}

--- a/src/parsers/moduleParser.ts
+++ b/src/parsers/moduleParser.ts
@@ -116,6 +116,9 @@ export function parseModule(sourceFile: ts.SourceFile, context: ScopedParserCont
 				const declarations = exportedSymbol.declarations;
 				let isTypeOnlyStarExport = false;
 				if (declarations && declarations.length > 0) {
+					// Type-only-ness is attributed to the declaring file, not the export
+					// path: when the same module is reached by both `export *` and
+					// `export type *`, its exports count as type-only.
 					const symbolSourceFile = declarations[0].getSourceFile();
 					isTypeOnlyStarExport = typeOnlySourceFiles.has(symbolSourceFile);
 					if (isTypeOnlyStarExport && !isPureType(exportedSymbol)) {

--- a/src/parsers/moduleParser.ts
+++ b/src/parsers/moduleParser.ts
@@ -125,17 +125,9 @@ export function parseModule(sourceFile: ts.SourceFile, context: ScopedParserCont
 					}
 				}
 
-				const parsedExports = parseExport(exportedSymbol, context);
+				const parsedExports = parseExport(exportedSymbol, context, [], isTypeOnlyStarExport);
 				if (!parsedExports) {
 					continue;
-				}
-				if (isTypeOnlyStarExport) {
-					// The surviving pure types can include enums, which occupy the value
-					// space at their declaration - but `export type *` only re-exports
-					// their type meaning.
-					for (const parsedExport of parsedExports) {
-						parsedExport.isValue = false;
-					}
 				}
 				parsedModuleExports.push(...parsedExports);
 			}

--- a/test/fixtures/alias-with-explicit-type-args/output.json
+++ b/test/fixtures/alias-with-explicit-type-args/output.json
@@ -270,7 +270,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/base-ui-component/output.json
+++ b/test/fixtures/base-ui-component/output.json
@@ -2182,7 +2182,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": true
 		},
 		{
 			"name": "BaseUIComponent1.Props",
@@ -2723,6 +2726,9 @@
 					}
 				]
 			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false,
 			"extendsTypes": [
 				{
 					"name": "BaseUIComponentProps"
@@ -2747,7 +2753,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "BaseUIComponent1.Actions",
@@ -2775,7 +2784,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "BaseUIComponent1.Value",
@@ -2786,7 +2798,10 @@
 					"namespaces": ["BaseUIComponent1"]
 				},
 				"intrinsic": "any"
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "BaseUIComponent1Value",
@@ -2802,7 +2817,10 @@
 						"intrinsic": "null"
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "BaseUIComponent2",
@@ -4477,7 +4495,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": true
 		},
 		{
 			"name": "BaseUIComponent2.Props",
@@ -4891,6 +4912,9 @@
 					}
 				]
 			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false,
 			"extendsTypes": [
 				{
 					"name": "BaseUIComponentProps"
@@ -4906,7 +4930,10 @@
 					"namespaces": ["BaseUIComponent2"]
 				},
 				"properties": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "ComponentRenderFn",
@@ -4932,7 +4959,10 @@
 					]
 				},
 				"props": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/base-ui-component/output.json
+++ b/test/fixtures/base-ui-component/output.json
@@ -2726,14 +2726,14 @@
 					}
 				]
 			},
-			"isValue": false,
-			"isType": true,
-			"isNamespace": false,
 			"extendsTypes": [
 				{
 					"name": "BaseUIComponentProps"
 				}
-			]
+			],
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "BaseUIComponent1.State",
@@ -4912,14 +4912,14 @@
 					}
 				]
 			},
-			"isValue": false,
-			"isType": true,
-			"isNamespace": false,
 			"extendsTypes": [
 				{
 					"name": "BaseUIComponentProps"
 				}
-			]
+			],
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "BaseUIComponent2.State",

--- a/test/fixtures/class-members-visibility-and-signatures/output.json
+++ b/test/fixtures/class-members-visibility-and-signatures/output.json
@@ -274,7 +274,10 @@
 						"value": "T - The type of items in the container."
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "ParameterPropertyClass",
@@ -344,7 +347,10 @@
 			"documentation": {
 				"description": "A class with constructor parameter properties.",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "GetterOnlyClass",
@@ -393,7 +399,10 @@
 			"documentation": {
 				"description": "A class with getter-only accessors (readonly by virtue of no setter).",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "OverloadedMethods",
@@ -520,7 +529,10 @@
 			"documentation": {
 				"description": "A class with method overloads.",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "FunctionPropertyClass",
@@ -612,7 +624,10 @@
 			"documentation": {
 				"description": "A class with function-typed properties (should be properties, not methods).",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "StaticMembersClass",
@@ -713,7 +728,10 @@
 			"documentation": {
 				"description": "A class with static members (should not appear in instance docs).",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "VisibilityTagsClass",
@@ -772,7 +790,10 @@
 						"value": "members."
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "EcmaPrivateClass",
@@ -825,7 +846,10 @@
 			"documentation": {
 				"description": "A class with ECMAScript private names (#field, #method).\nThese should NOT appear in the output since they are always private.",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Constructable",
@@ -839,7 +863,10 @@
 			"documentation": {
 				"description": "This should NOT be parsed as a class - it's an interface with a construct signature.",
 				"tags": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "ConstructableType",
@@ -853,7 +880,10 @@
 			"documentation": {
 				"description": "This should NOT be parsed as a class - it's a type alias with a construct signature.",
 				"tags": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/class-method-generic-signatures/output.json
+++ b/test/fixtures/class-method-generic-signatures/output.json
@@ -260,7 +260,10 @@
 						"name": "T"
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/class-method-overload-signatures/output.json
+++ b/test/fixtures/class-method-overload-signatures/output.json
@@ -228,7 +228,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/class-private-members-type-alias-filtering/output.json
+++ b/test/fixtures/class-private-members-type-alias-filtering/output.json
@@ -18,7 +18,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/distributive-conditional-intersection-expansion/output.json
+++ b/test/fixtures/distributive-conditional-intersection-expansion/output.json
@@ -296,7 +296,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/enum-members-values-and-docs/output.json
+++ b/test/fixtures/enum-members-values-and-docs/output.json
@@ -34,7 +34,10 @@
 			"documentation": {
 				"description": "Description of the Side enum.",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Flags",
@@ -65,7 +68,10 @@
 					}
 				],
 				"kind": "enum"
-			}
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "DegenerateN",
@@ -80,7 +86,10 @@
 					}
 				],
 				"kind": "enum"
-			}
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "DegenerateS",
@@ -95,7 +104,10 @@
 					}
 				],
 				"kind": "enum"
-			}
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/export-declaration-spaces/dual-enums.ts
+++ b/test/fixtures/export-declaration-spaces/dual-enums.ts
@@ -1,0 +1,3 @@
+export enum DualStarEnum {
+	member = 'member',
+}

--- a/test/fixtures/export-declaration-spaces/enums.ts
+++ b/test/fixtures/export-declaration-spaces/enums.ts
@@ -1,0 +1,3 @@
+export enum StarEnum {
+	member = 'member',
+}

--- a/test/fixtures/export-declaration-spaces/helpers.ts
+++ b/test/fixtures/export-declaration-spaces/helpers.ts
@@ -9,3 +9,7 @@ export class ReexportedClass {
 export function mergedTarget(): string {
 	return 'merged-target';
 }
+
+export function typeOnlyImported(): string {
+	return 'type-only-imported';
+}

--- a/test/fixtures/export-declaration-spaces/helpers.ts
+++ b/test/fixtures/export-declaration-spaces/helpers.ts
@@ -1,0 +1,3 @@
+export type ReexportedAlias = 'reexported';
+
+export const reexportedValue = 'reexported';

--- a/test/fixtures/export-declaration-spaces/helpers.ts
+++ b/test/fixtures/export-declaration-spaces/helpers.ts
@@ -1,3 +1,11 @@
 export type ReexportedAlias = 'reexported';
 
 export const reexportedValue = 'reexported';
+
+export class ReexportedClass {
+	id: string = 'class';
+}
+
+export function mergedTarget(): string {
+	return 'merged-target';
+}

--- a/test/fixtures/export-declaration-spaces/input.ts
+++ b/test/fixtures/export-declaration-spaces/input.ts
@@ -1,0 +1,39 @@
+// A type alias and a constant annotated with it resolve to the same literal
+// type; only the declaration spaces tell them apart.
+export type PlainAlias = 'alias';
+
+export const annotatedConstant: PlainAlias = 'alias';
+
+export const plainConstant = 'constant';
+
+export function plainFunction(): string {
+	return 'function';
+}
+
+export class PlainClass {
+	id: string = 'class';
+}
+
+export enum PlainEnum {
+	member = 'member',
+}
+
+export interface PlainInterface {
+	id: string;
+}
+
+// Merged declarations occupy both the value and the type space.
+export interface Merged {
+	id: string;
+}
+
+export const Merged: Merged = { id: 'merged' };
+
+// A namespace containing only types occupies just the namespace space.
+export namespace TypesNamespace {
+	export type Nested = 'nested';
+}
+
+export type { ReexportedAlias } from './helpers';
+
+export { reexportedValue } from './helpers';

--- a/test/fixtures/export-declaration-spaces/input.ts
+++ b/test/fixtures/export-declaration-spaces/input.ts
@@ -1,4 +1,5 @@
 import { mergedTarget } from './helpers';
+import type { typeOnlyImported } from './helpers';
 
 // A type alias and a constant annotated with it resolve to the same literal
 // type; only the declaration spaces tell them apart.
@@ -54,6 +55,31 @@ namespace TypesNamespace {
 
 export type { TypesNamespace };
 
+// A function merged with a namespace occupies the value and namespace spaces.
+export function fnWithNs(): string {
+	return 'fn-with-ns';
+}
+
+export namespace fnWithNs {
+	export type Nested = 'nested';
+}
+
+// A type-only export of a merged namespace masks the value space of its
+// members too: nothing crosses the export site at runtime.
+function nsFn(): string {
+	return 'ns-fn';
+}
+
+namespace nsFn {
+	export const inner = 'inner';
+}
+
+export type { nsFn };
+
+// A value re-exported through a type-only import has no runtime binding,
+// even though the export specifier itself is not type-only.
+export { typeOnlyImported };
+
 // Type-only re-exports never occupy the value space, whatever their target is.
 export type { ReexportedAlias, ReexportedClass } from './helpers';
 
@@ -61,3 +87,8 @@ export { reexportedValue } from './helpers';
 
 // An enum survives a type-only star export as a type, not as a value.
 export type * from './enums';
+
+// A default-exported class occupies the value and type spaces like any class.
+export default class DefaultClass {
+	id: string = 'default';
+}

--- a/test/fixtures/export-declaration-spaces/input.ts
+++ b/test/fixtures/export-declaration-spaces/input.ts
@@ -1,3 +1,5 @@
+import { mergedTarget } from './helpers';
+
 // A type alias and a constant annotated with it resolve to the same literal
 // type; only the declaration spaces tell them apart.
 export type PlainAlias = 'alias';
@@ -9,6 +11,13 @@ export const plainConstant = 'constant';
 export function plainFunction(): string {
 	return 'function';
 }
+
+// Expando assignments make the binder set SymbolFlags.Module, but they do not
+// declare a namespace.
+export function expandoFunction(): string {
+	return 'expando';
+}
+expandoFunction.extra = 'extra';
 
 export class PlainClass {
 	id: string = 'class';
@@ -29,11 +38,26 @@ export interface Merged {
 
 export const Merged: Merged = { id: 'merged' };
 
-// A namespace containing only types occupies just the namespace space.
-export namespace TypesNamespace {
+// An imported value merged with a local interface occupies the spaces of both.
+interface mergedTarget {
+	id: string;
+}
+
+export { mergedTarget };
+
+// A namespace containing only types occupies just the namespace space. It is
+// exported through a specifier because a directly exported namespace is
+// flattened into its members.
+namespace TypesNamespace {
 	export type Nested = 'nested';
 }
 
-export type { ReexportedAlias } from './helpers';
+export type { TypesNamespace };
+
+// Type-only re-exports never occupy the value space, whatever their target is.
+export type { ReexportedAlias, ReexportedClass } from './helpers';
 
 export { reexportedValue } from './helpers';
+
+// An enum survives a type-only star export as a type, not as a value.
+export type * from './enums';

--- a/test/fixtures/export-declaration-spaces/input.ts
+++ b/test/fixtures/export-declaration-spaces/input.ts
@@ -88,6 +88,18 @@ export { reexportedValue } from './helpers';
 // An enum survives a type-only star export as a type, not as a value.
 export type * from './enums';
 
+// Reaching the same module both ways keeps the value space: the plain star export
+// carries the runtime binding regardless of the type-only one.
+export * from './dual-enums';
+export type * from './dual-enums';
+
+// A type-only namespace re-export masks the value space of its members too,
+// like every other type-only export site.
+export type * as TypeOnlyNamespace from './helpers';
+
+// The same re-export without `type` keeps the value space.
+export * as ValueNamespace from './helpers';
+
 // A default-exported class occupies the value and type spaces like any class.
 export default class DefaultClass {
 	id: string = 'default';

--- a/test/fixtures/export-declaration-spaces/output.json
+++ b/test/fixtures/export-declaration-spaces/output.json
@@ -1,0 +1,182 @@
+{
+	"name": "test/fixtures/export-declaration-spaces/input",
+	"exports": [
+		{
+			"name": "plainFunction",
+			"type": {
+				"kind": "function",
+				"typeName": {
+					"name": "plainFunction"
+				},
+				"callSignatures": [
+					{
+						"parameters": [],
+						"returnValueType": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						}
+					}
+				]
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
+		},
+		{
+			"name": "PlainAlias",
+			"type": {
+				"kind": "literal",
+				"value": "\"alias\""
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
+		},
+		{
+			"name": "annotatedConstant",
+			"type": {
+				"kind": "literal",
+				"value": "\"alias\""
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
+		},
+		{
+			"name": "plainConstant",
+			"type": {
+				"kind": "literal",
+				"value": "\"constant\""
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
+		},
+		{
+			"name": "PlainClass",
+			"type": {
+				"kind": "class",
+				"typeName": {
+					"name": "PlainClass"
+				},
+				"constructSignatures": [
+					{
+						"parameters": []
+					}
+				],
+				"properties": [
+					{
+						"name": "id",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false,
+						"readonly": false,
+						"isStatic": false
+					}
+				],
+				"methods": []
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
+		},
+		{
+			"name": "PlainEnum",
+			"type": {
+				"typeName": {
+					"name": "PlainEnum"
+				},
+				"members": [
+					{
+						"name": "member",
+						"value": "member"
+					}
+				],
+				"kind": "enum"
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
+		},
+		{
+			"name": "PlainInterface",
+			"type": {
+				"kind": "object",
+				"typeName": {
+					"name": "PlainInterface"
+				},
+				"properties": [
+					{
+						"name": "id",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					}
+				]
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
+		},
+		{
+			"name": "Merged",
+			"type": {
+				"kind": "object",
+				"typeName": {
+					"name": "Merged"
+				},
+				"properties": [
+					{
+						"name": "id",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false
+					}
+				]
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
+		},
+		{
+			"name": "TypesNamespace.Nested",
+			"type": {
+				"kind": "literal",
+				"value": "\"nested\"",
+				"typeName": {
+					"name": "Nested",
+					"namespaces": ["TypesNamespace"]
+				}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
+		},
+		{
+			"name": "ReexportedAlias",
+			"type": {
+				"kind": "literal",
+				"value": "\"reexported\""
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
+		},
+		{
+			"name": "reexportedValue",
+			"type": {
+				"kind": "literal",
+				"value": "\"reexported\""
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
+		}
+	]
+}

--- a/test/fixtures/export-declaration-spaces/output.json
+++ b/test/fixtures/export-declaration-spaces/output.json
@@ -23,6 +23,27 @@
 			"isNamespace": false
 		},
 		{
+			"name": "expandoFunction",
+			"type": {
+				"kind": "function",
+				"typeName": {
+					"name": "expandoFunction"
+				},
+				"callSignatures": [
+					{
+						"parameters": [],
+						"returnValueType": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						}
+					}
+				]
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
+		},
+		{
 			"name": "PlainAlias",
 			"type": {
 				"kind": "literal",
@@ -145,6 +166,37 @@
 			"isNamespace": false
 		},
 		{
+			"name": "mergedTarget",
+			"type": {
+				"kind": "function",
+				"typeName": {
+					"name": "mergedTarget"
+				},
+				"callSignatures": [
+					{
+						"parameters": [],
+						"returnValueType": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						}
+					}
+				]
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
+		},
+		{
+			"name": "TypesNamespace",
+			"type": {
+				"kind": "intrinsic",
+				"intrinsic": "any"
+			},
+			"isValue": false,
+			"isType": false,
+			"isNamespace": true
+		},
+		{
 			"name": "TypesNamespace.Nested",
 			"type": {
 				"kind": "literal",
@@ -169,6 +221,36 @@
 			"isNamespace": false
 		},
 		{
+			"name": "ReexportedClass",
+			"type": {
+				"kind": "class",
+				"typeName": {
+					"name": "ReexportedClass"
+				},
+				"constructSignatures": [
+					{
+						"parameters": []
+					}
+				],
+				"properties": [
+					{
+						"name": "id",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false,
+						"readonly": false,
+						"isStatic": false
+					}
+				],
+				"methods": []
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
+		},
+		{
 			"name": "reexportedValue",
 			"type": {
 				"kind": "literal",
@@ -177,6 +259,25 @@
 			"isValue": true,
 			"isType": false,
 			"isNamespace": false
+		},
+		{
+			"name": "StarEnum",
+			"type": {
+				"typeName": {
+					"name": "StarEnum"
+				},
+				"members": [
+					{
+						"name": "member",
+						"value": "member"
+					}
+				],
+				"kind": "enum"
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
-	]
+	],
+	"imports": ["./helpers"]
 }

--- a/test/fixtures/export-declaration-spaces/output.json
+++ b/test/fixtures/export-declaration-spaces/output.json
@@ -352,6 +352,212 @@
 			"isNamespace": false
 		},
 		{
+			"name": "TypeOnlyNamespace.mergedTarget",
+			"type": {
+				"kind": "function",
+				"typeName": {
+					"name": "mergedTarget",
+					"namespaces": ["TypeOnlyNamespace"]
+				},
+				"callSignatures": [
+					{
+						"parameters": [],
+						"returnValueType": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						}
+					}
+				]
+			},
+			"isValue": false,
+			"isType": false,
+			"isNamespace": false
+		},
+		{
+			"name": "TypeOnlyNamespace.typeOnlyImported",
+			"type": {
+				"kind": "function",
+				"typeName": {
+					"name": "typeOnlyImported",
+					"namespaces": ["TypeOnlyNamespace"]
+				},
+				"callSignatures": [
+					{
+						"parameters": [],
+						"returnValueType": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						}
+					}
+				]
+			},
+			"isValue": false,
+			"isType": false,
+			"isNamespace": false
+		},
+		{
+			"name": "TypeOnlyNamespace.ReexportedAlias",
+			"type": {
+				"kind": "literal",
+				"value": "\"reexported\"",
+				"typeName": {
+					"name": "ReexportedAlias",
+					"namespaces": ["TypeOnlyNamespace"]
+				}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
+		},
+		{
+			"name": "TypeOnlyNamespace.reexportedValue",
+			"type": {
+				"kind": "literal",
+				"value": "\"reexported\"",
+				"typeName": {
+					"name": "reexportedValue",
+					"namespaces": ["TypeOnlyNamespace"]
+				}
+			},
+			"isValue": false,
+			"isType": false,
+			"isNamespace": false
+		},
+		{
+			"name": "TypeOnlyNamespace.ReexportedClass",
+			"type": {
+				"kind": "class",
+				"typeName": {
+					"name": "ReexportedClass",
+					"namespaces": ["TypeOnlyNamespace"]
+				},
+				"constructSignatures": [
+					{
+						"parameters": []
+					}
+				],
+				"properties": [
+					{
+						"name": "id",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false,
+						"readonly": false,
+						"isStatic": false
+					}
+				],
+				"methods": []
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
+		},
+		{
+			"name": "ValueNamespace.mergedTarget",
+			"type": {
+				"kind": "function",
+				"typeName": {
+					"name": "mergedTarget",
+					"namespaces": ["ValueNamespace"]
+				},
+				"callSignatures": [
+					{
+						"parameters": [],
+						"returnValueType": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						}
+					}
+				]
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
+		},
+		{
+			"name": "ValueNamespace.typeOnlyImported",
+			"type": {
+				"kind": "function",
+				"typeName": {
+					"name": "typeOnlyImported",
+					"namespaces": ["ValueNamespace"]
+				},
+				"callSignatures": [
+					{
+						"parameters": [],
+						"returnValueType": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						}
+					}
+				]
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
+		},
+		{
+			"name": "ValueNamespace.ReexportedAlias",
+			"type": {
+				"kind": "literal",
+				"value": "\"reexported\"",
+				"typeName": {
+					"name": "ReexportedAlias",
+					"namespaces": ["ValueNamespace"]
+				}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
+		},
+		{
+			"name": "ValueNamespace.reexportedValue",
+			"type": {
+				"kind": "literal",
+				"value": "\"reexported\"",
+				"typeName": {
+					"name": "reexportedValue",
+					"namespaces": ["ValueNamespace"]
+				}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
+		},
+		{
+			"name": "ValueNamespace.ReexportedClass",
+			"type": {
+				"kind": "class",
+				"typeName": {
+					"name": "ReexportedClass",
+					"namespaces": ["ValueNamespace"]
+				},
+				"constructSignatures": [
+					{
+						"parameters": []
+					}
+				],
+				"properties": [
+					{
+						"name": "id",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false,
+						"readonly": false,
+						"isStatic": false
+					}
+				],
+				"methods": []
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
+		},
+		{
 			"name": "default",
 			"type": {
 				"kind": "class",
@@ -396,6 +602,24 @@
 				"kind": "enum"
 			},
 			"isValue": false,
+			"isType": true,
+			"isNamespace": false
+		},
+		{
+			"name": "DualStarEnum",
+			"type": {
+				"typeName": {
+					"name": "DualStarEnum"
+				},
+				"members": [
+					{
+						"name": "member",
+						"value": "member"
+					}
+				],
+				"kind": "enum"
+			},
+			"isValue": true,
 			"isType": true,
 			"isNamespace": false
 		}

--- a/test/fixtures/export-declaration-spaces/output.json
+++ b/test/fixtures/export-declaration-spaces/output.json
@@ -44,6 +44,41 @@
 			"isNamespace": false
 		},
 		{
+			"name": "fnWithNs",
+			"type": {
+				"kind": "function",
+				"typeName": {
+					"name": "fnWithNs"
+				},
+				"callSignatures": [
+					{
+						"parameters": [],
+						"returnValueType": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						}
+					}
+				]
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": true
+		},
+		{
+			"name": "fnWithNs.Nested",
+			"type": {
+				"kind": "literal",
+				"value": "\"nested\"",
+				"typeName": {
+					"name": "Nested",
+					"namespaces": ["fnWithNs"]
+				}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
+		},
+		{
 			"name": "PlainAlias",
 			"type": {
 				"kind": "literal",
@@ -211,6 +246,62 @@
 			"isNamespace": false
 		},
 		{
+			"name": "nsFn",
+			"type": {
+				"kind": "function",
+				"typeName": {
+					"name": "nsFn"
+				},
+				"callSignatures": [
+					{
+						"parameters": [],
+						"returnValueType": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						}
+					}
+				]
+			},
+			"isValue": false,
+			"isType": false,
+			"isNamespace": true
+		},
+		{
+			"name": "nsFn.inner",
+			"type": {
+				"kind": "literal",
+				"value": "\"inner\"",
+				"typeName": {
+					"name": "inner",
+					"namespaces": ["nsFn"]
+				}
+			},
+			"isValue": false,
+			"isType": false,
+			"isNamespace": false
+		},
+		{
+			"name": "typeOnlyImported",
+			"type": {
+				"kind": "function",
+				"typeName": {
+					"name": "typeOnlyImported"
+				},
+				"callSignatures": [
+					{
+						"parameters": [],
+						"returnValueType": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						}
+					}
+				]
+			},
+			"isValue": false,
+			"isType": false,
+			"isNamespace": false
+		},
+		{
 			"name": "ReexportedAlias",
 			"type": {
 				"kind": "literal",
@@ -261,6 +352,36 @@
 			"isNamespace": false
 		},
 		{
+			"name": "default",
+			"type": {
+				"kind": "class",
+				"typeName": {
+					"name": "default"
+				},
+				"constructSignatures": [
+					{
+						"parameters": []
+					}
+				],
+				"properties": [
+					{
+						"name": "id",
+						"type": {
+							"kind": "intrinsic",
+							"intrinsic": "string"
+						},
+						"optional": false,
+						"readonly": false,
+						"isStatic": false
+					}
+				],
+				"methods": []
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
+		},
+		{
 			"name": "StarEnum",
 			"type": {
 				"typeName": {
@@ -279,5 +400,5 @@
 			"isNamespace": false
 		}
 	],
-	"imports": ["./helpers"]
+	"imports": ["./helpers", "./helpers"]
 }

--- a/test/fixtures/external-conditional-type-resolution/output.json
+++ b/test/fixtures/external-conditional-type-resolution/output.json
@@ -52,7 +52,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	],
 	"imports": ["./external-types"]

--- a/test/fixtures/external-mapped-type-name-preservation/output.json
+++ b/test/fixtures/external-mapped-type-name-preservation/output.json
@@ -35,7 +35,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	],
 	"imports": ["floating-ui"]

--- a/test/fixtures/external-union-type-name-preservation/output.json
+++ b/test/fixtures/external-union-type-name-preservation/output.json
@@ -102,10 +102,10 @@
 				"description": "A rectangle with x, y coordinates and width, height dimensions.\n\nTypeScript will resolve this to Prettify<Coords & Dimensions>,\nbut consumers should see \"Rect\" in their type information.",
 				"tags": []
 			},
+			"reexportedFrom": "Rect",
 			"isValue": false,
 			"isType": true,
-			"isNamespace": false,
-			"reexportedFrom": "Rect"
+			"isNamespace": false
 		},
 		{
 			"name": "PositioningProps",

--- a/test/fixtures/external-union-type-name-preservation/output.json
+++ b/test/fixtures/external-union-type-name-preservation/output.json
@@ -39,7 +39,10 @@
 			"documentation": {
 				"description": "A boundary can be the clipping ancestors, an element, or a Rect.\nThe Rect type should be preserved as \"Rect\" not expanded to its underlying type.",
 				"tags": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Anchor",
@@ -66,7 +69,10 @@
 			"documentation": {
 				"description": "An anchor can be an element or a Point.",
 				"tags": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Padding",
@@ -79,7 +85,10 @@
 			"documentation": {
 				"description": "Padding can be a number or a partial side object.\nThis is a UNION type that should be EXPANDED (not collapsed to just \"Padding\").",
 				"tags": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "NestedRect",
@@ -93,6 +102,9 @@
 				"description": "A rectangle with x, y coordinates and width, height dimensions.\n\nTypeScript will resolve this to Prettify<Coords & Dimensions>,\nbut consumers should see \"Rect\" in their type information.",
 				"tags": []
 			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false,
 			"reexportedFrom": "Rect"
 		},
 		{
@@ -251,7 +263,10 @@
 			"documentation": {
 				"description": "Props that use external types in unions.",
 				"tags": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	],
 	"imports": ["external-lib", "external-lib-wrapper"]

--- a/test/fixtures/function-callable-intersection-extra-properties/output.json
+++ b/test/fixtures/function-callable-intersection-extra-properties/output.json
@@ -23,7 +23,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": true
 		},
 		{
 			"name": "TestComponent",
@@ -39,7 +42,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": true
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/function-callable-intersection-extra-properties/output.json
+++ b/test/fixtures/function-callable-intersection-extra-properties/output.json
@@ -26,7 +26,7 @@
 			},
 			"isValue": true,
 			"isType": false,
-			"isNamespace": true
+			"isNamespace": false
 		},
 		{
 			"name": "TestComponent",
@@ -45,7 +45,7 @@
 			},
 			"isValue": true,
 			"isType": false,
-			"isNamespace": true
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/function-declaration-expression-arrow/output.json
+++ b/test/fixtures/function-declaration-expression-arrow/output.json
@@ -38,7 +38,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "greetAsExpression",
@@ -74,7 +77,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "greetAsArrowFunction",
@@ -110,7 +116,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/function-parameters-optional-and-defaults/output.json
+++ b/test/fixtures/function-parameters-optional-and-defaults/output.json
@@ -77,7 +77,10 @@
 			"documentation": {
 				"description": "Function with optional parameters",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/generic-argument-alias-resolution/output.json
+++ b/test/fixtures/generic-argument-alias-resolution/output.json
@@ -71,7 +71,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/generic-callback-alias-constraint-deduplication/output.json
+++ b/test/fixtures/generic-callback-alias-constraint-deduplication/output.json
@@ -110,7 +110,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/generic-callback-alias-renamed-typeparams/output.json
+++ b/test/fixtures/generic-callback-alias-renamed-typeparams/output.json
@@ -66,7 +66,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "AlphaEquivAliasConstrained",
@@ -153,7 +156,10 @@
 			"documentation": {
 				"description": "Same scenario but with constrained type parameters.",
 				"tags": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "NonEquivAliasDifferentConstraints",
@@ -312,7 +318,10 @@
 			"documentation": {
 				"description": "Non-equivalent: different constraints mean the branches should NOT deduplicate.",
 				"tags": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/generic-callback-alias-vs-inline-deduplication/output.json
+++ b/test/fixtures/generic-callback-alias-vs-inline-deduplication/output.json
@@ -104,7 +104,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/generic-callback-constraint-property-keys/output.json
+++ b/test/fixtures/generic-callback-constraint-property-keys/output.json
@@ -102,7 +102,10 @@
 			"documentation": {
 				"description": "Union of generic callbacks whose type parameter names differ and whose\nconstraints contain property keys matching those type parameter names.\nThese are NOT alpha-equivalent because { T: string } !== { U: string }.\nBoth signatures must be preserved in the output.",
 				"tags": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/generic-callback-default-deduplication/output.json
+++ b/test/fixtures/generic-callback-default-deduplication/output.json
@@ -66,7 +66,10 @@
 			"documentation": {
 				"description": "Union of generic callbacks that differ only by type parameter defaults.\nEach signature should be preserved since they have different defaults.",
 				"tags": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/generic-callback-index-signature-deduplication/output.json
+++ b/test/fixtures/generic-callback-index-signature-deduplication/output.json
@@ -98,7 +98,10 @@
 			"documentation": {
 				"description": "Union of generic callbacks whose constraints are objects with differing\nindex signatures. These should NOT be deduplicated.",
 				"tags": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/generic-callback-nested-shadow-deduplication/output.json
+++ b/test/fixtures/generic-callback-nested-shadow-deduplication/output.json
@@ -84,7 +84,10 @@
 			"documentation": {
 				"description": "Nested generic function types where inner signatures reuse the same\ntype parameter name as an outer mapping. Inner T should shadow outer T\nand not incorrectly resolve via the outer rename map.",
 				"tags": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/generic-callback-typeparam-vs-typename-collision/output.json
+++ b/test/fixtures/generic-callback-typeparam-vs-typename-collision/output.json
@@ -188,7 +188,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "AlphaEquiv",
@@ -301,7 +304,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/generic-constraint-tostring-collapse/output.json
+++ b/test/fixtures/generic-constraint-tostring-collapse/output.json
@@ -76,7 +76,10 @@
 			"documentation": {
 				"description": "Tests that generic functions with different type parameter constraints\nare not incorrectly collapsed by the toString() fast-path.\nTypeParameterNode.toString() returns only the name (e.g. \"T\"), omitting\nconstraints and defaults, so `<T>(x: T) => void` and\n`<T extends string>(x: T) => void` stringify identically.\nBoth overloads must be preserved.",
 				"tags": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Outer",
@@ -183,7 +186,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/generic-default-argument-resolution/output.json
+++ b/test/fixtures/generic-default-argument-resolution/output.json
@@ -47,7 +47,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "stringParam",
@@ -95,7 +98,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "numberParam",
@@ -143,7 +149,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "genericParam",
@@ -197,7 +206,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "defaultPair",
@@ -260,7 +272,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "stringPair",
@@ -323,7 +338,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "numberPair",
@@ -386,7 +404,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "partialStringPair",
@@ -449,7 +470,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "partialNumberPair",
@@ -512,7 +536,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/generic-function-and-interface-resolution/output.json
+++ b/test/fixtures/generic-function-and-interface-resolution/output.json
@@ -196,7 +196,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/generic-props-namespace-specialization/output.json
+++ b/test/fixtures/generic-props-namespace-specialization/output.json
@@ -379,7 +379,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "GenericHTMLProps",
@@ -471,7 +474,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/interface-extends-basic-resolution/output.json
+++ b/test/fixtures/interface-extends-basic-resolution/output.json
@@ -27,14 +27,14 @@
 					}
 				]
 			},
-			"isValue": false,
-			"isType": true,
-			"isNamespace": false,
 			"extendsTypes": [
 				{
 					"name": "BaseProps"
 				}
-			]
+			],
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "MultiExtendedProps",
@@ -70,9 +70,6 @@
 					}
 				]
 			},
-			"isValue": false,
-			"isType": true,
-			"isNamespace": false,
 			"extendsTypes": [
 				{
 					"name": "BaseProps"
@@ -80,7 +77,10 @@
 				{
 					"name": "AnotherBase"
 				}
-			]
+			],
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "AlertDialogProps",
@@ -108,15 +108,15 @@
 					}
 				]
 			},
-			"isValue": false,
-			"isType": true,
-			"isNamespace": false,
 			"extendsTypes": [
 				{
 					"name": "Dialog.Props",
 					"resolvedName": "DialogProps"
 				}
-			]
+			],
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Dialog",

--- a/test/fixtures/interface-extends-basic-resolution/output.json
+++ b/test/fixtures/interface-extends-basic-resolution/output.json
@@ -27,6 +27,9 @@
 					}
 				]
 			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false,
 			"extendsTypes": [
 				{
 					"name": "BaseProps"
@@ -67,6 +70,9 @@
 					}
 				]
 			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false,
 			"extendsTypes": [
 				{
 					"name": "BaseProps"
@@ -102,6 +108,9 @@
 					}
 				]
 			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false,
 			"extendsTypes": [
 				{
 					"name": "Dialog.Props",
@@ -114,7 +123,10 @@
 			"type": {
 				"kind": "intrinsic",
 				"intrinsic": "any"
-			}
+			},
+			"isValue": false,
+			"isType": false,
+			"isNamespace": true
 		},
 		{
 			"name": "Dialog.Props",
@@ -134,7 +146,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/interface-extends-namespace-and-omit-resolution/output.json
+++ b/test/fixtures/interface-extends-namespace-and-omit-resolution/output.json
@@ -242,7 +242,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "DialogRootActions",
@@ -291,7 +294,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "DialogRootChangeEventReason",
@@ -314,7 +320,10 @@
 						"value": "\"focus-out\""
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "DialogRootChangeEventDetails",
@@ -368,7 +377,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "DialogRoot.Props",
@@ -612,7 +624,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "DialogRoot.Actions",
@@ -662,7 +677,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "DialogRoot.ChangeEventReason",
@@ -686,7 +704,10 @@
 						"value": "\"focus-out\""
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "DialogRoot.ChangeEventDetails",
@@ -741,7 +762,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "AlertDialogRootProps",
@@ -1064,6 +1088,9 @@
 					}
 				]
 			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false,
 			"extendsTypes": [
 				{
 					"name": "DialogRoot.Props",
@@ -1119,7 +1146,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "AlertDialogRootChangeEventReason",
@@ -1143,7 +1173,10 @@
 						"value": "\"focus-out\""
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "AlertDialogRootChangeEventDetails",
@@ -1305,7 +1338,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "AlertDialogRoot.Props",
@@ -1628,7 +1664,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "AlertDialogRoot.Actions",
@@ -1678,7 +1717,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "AlertDialogRoot.ChangeEventReason",
@@ -1702,7 +1744,10 @@
 						"value": "\"focus-out\""
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "AlertDialogRoot.ChangeEventDetails",
@@ -1865,7 +1910,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/interface-extends-namespace-and-omit-resolution/output.json
+++ b/test/fixtures/interface-extends-namespace-and-omit-resolution/output.json
@@ -1088,15 +1088,15 @@
 					}
 				]
 			},
-			"isValue": false,
-			"isType": true,
-			"isNamespace": false,
 			"extendsTypes": [
 				{
 					"name": "DialogRoot.Props",
 					"resolvedName": "DialogRootProps"
 				}
-			]
+			],
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "AlertDialogRootActions",

--- a/test/fixtures/interface-merged-default-and-aliased-exports/output.json
+++ b/test/fixtures/interface-merged-default-and-aliased-exports/output.json
@@ -26,7 +26,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Interface2",
@@ -45,7 +48,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Interface2Alias",
@@ -64,7 +70,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "default",
@@ -100,7 +109,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/interface-method-generic-signatures/output.json
+++ b/test/fixtures/interface-method-generic-signatures/output.json
@@ -420,7 +420,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/intersection-order-deduplication/output.json
+++ b/test/fixtures/intersection-order-deduplication/output.json
@@ -82,7 +82,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "IntersectionNotEquivalent",
@@ -237,7 +240,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/jsdoc-comments-and-overloads/output.json
+++ b/test/fixtures/jsdoc-comments-and-overloads/output.json
@@ -58,7 +58,10 @@
 				"description": "The test component.",
 				"visibility": "internal",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "testFunction",
@@ -169,7 +172,10 @@
 						"value": "testFunction('test', 10);"
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/jsdoc-extra-tags-preservation/output.json
+++ b/test/fixtures/jsdoc-extra-tags-preservation/output.json
@@ -168,7 +168,10 @@
 						"value": "important-functions"
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/large-nested-union-any-order/output.json
+++ b/test/fixtures/large-nested-union-any-order/output.json
@@ -116,7 +116,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "LargeNestedUnionAnyFirst",
@@ -233,7 +236,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "LargeNestedUnionAnySecond",
@@ -350,7 +356,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/mapped-alias-finite-key/output.json
+++ b/test/fixtures/mapped-alias-finite-key/output.json
@@ -54,7 +54,10 @@
 						]
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Specialized",
@@ -99,7 +102,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "LiteralWrapped",
@@ -131,7 +137,10 @@
 					]
 				},
 				"properties": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/mapped-alias-nested-mapped-value/output.json
+++ b/test/fixtures/mapped-alias-nested-mapped-value/output.json
@@ -82,7 +82,10 @@
 						]
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Use",
@@ -157,7 +160,10 @@
 						]
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/mapped-alias-nested-value/output.json
+++ b/test/fixtures/mapped-alias-nested-value/output.json
@@ -63,7 +63,10 @@
 						]
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Wrapped",
@@ -127,7 +130,10 @@
 						]
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "UseWrapped",
@@ -176,7 +182,10 @@
 						]
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/mapped-alias-two-hop/output.json
+++ b/test/fixtures/mapped-alias-two-hop/output.json
@@ -54,7 +54,10 @@
 						]
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Middle",
@@ -109,7 +112,10 @@
 						]
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Outer",
@@ -164,7 +170,10 @@
 						]
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "UseOuter",
@@ -204,7 +213,10 @@
 						]
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/mapped-tuple-rest-synthetic-key/output.json
+++ b/test/fixtures/mapped-tuple-rest-synthetic-key/output.json
@@ -34,7 +34,10 @@
 						"kind": "typeParameter"
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Wrap",
@@ -53,7 +56,10 @@
 					]
 				},
 				"properties": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Result",
@@ -132,7 +138,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/mapped-type-builtin-utility-resolution/output.json
+++ b/test/fixtures/mapped-type-builtin-utility-resolution/output.json
@@ -64,7 +64,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "requiredAlias",
@@ -111,7 +114,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "inlinePartial",
@@ -214,7 +220,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "inlineRequired",
@@ -299,7 +308,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/mapped-type-optional-aliased-unknown/output.json
+++ b/test/fixtures/mapped-type-optional-aliased-unknown/output.json
@@ -43,7 +43,10 @@
 						]
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/mapped-type-prettify-intersection-resolution/output.json
+++ b/test/fixtures/mapped-type-prettify-intersection-resolution/output.json
@@ -74,7 +74,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "Props",
@@ -129,7 +132,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/merged-interface-signature-typeparams/output.json
+++ b/test/fixtures/merged-interface-signature-typeparams/output.json
@@ -102,7 +102,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/module-dts-declarations-and-reexports/output.json
+++ b/test/fixtures/module-dts-declarations-and-reexports/output.json
@@ -92,7 +92,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "wrapValue",
@@ -181,7 +184,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "FormattedProperty",
@@ -217,7 +223,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "FormattedParameter",
@@ -261,7 +270,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "TypeContainer",
@@ -324,7 +336,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "ProcessingStatus",
@@ -356,7 +371,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "formatType",
@@ -412,7 +430,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "parseParameters",
@@ -479,7 +500,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["./source.js"]

--- a/test/fixtures/module-export-forms/output.json
+++ b/test/fixtures/module-export-forms/output.json
@@ -17,7 +17,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "default",
@@ -44,7 +47,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "overloadedFunction",
@@ -87,7 +93,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "aliasedOverloadedFunction",
@@ -130,7 +139,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "functionAndNamespaceDeclaration",
@@ -195,7 +207,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": true
 		},
 		{
 			"name": "functionAndNamespaceDeclaration.Params",
@@ -215,7 +230,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/module-reexport-imported-class-type/output.json
+++ b/test/fixtures/module-reexport-imported-class-type/output.json
@@ -65,7 +65,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
 		}
 	],
 	"imports": ["./source"]

--- a/test/fixtures/module-reexport-imported-class-type/output.json
+++ b/test/fixtures/module-reexport-imported-class-type/output.json
@@ -66,7 +66,7 @@
 					}
 				]
 			},
-			"isValue": true,
+			"isValue": false,
 			"isType": true,
 			"isNamespace": false
 		}

--- a/test/fixtures/module-reexports-aliased-source-tracking/output.json
+++ b/test/fixtures/module-reexports-aliased-source-tracking/output.json
@@ -90,6 +90,9 @@
 				"description": "The root component for an alert dialog.",
 				"tags": []
 			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": true,
 			"reexportedFrom": "AlertDialogRoot"
 		},
 		{
@@ -177,6 +180,9 @@
 					}
 				]
 			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false,
 			"extendsTypes": [
 				{
 					"name": "AlertDialogRootProps"
@@ -234,6 +240,9 @@
 				"description": "A button that opens the dialog.",
 				"tags": []
 			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": true,
 			"reexportedFrom": "DialogTrigger"
 		},
 		{
@@ -283,6 +292,9 @@
 					}
 				]
 			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false,
 			"extendsTypes": [
 				{
 					"name": "DialogTriggerProps"
@@ -325,6 +337,9 @@
 				"description": "An overlay that covers the page behind the dialog.",
 				"tags": []
 			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": true,
 			"reexportedFrom": "DialogBackdrop"
 		},
 		{
@@ -359,6 +374,9 @@
 					}
 				]
 			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false,
 			"extendsTypes": [
 				{
 					"name": "DialogBackdropProps"

--- a/test/fixtures/module-reexports-aliased-source-tracking/output.json
+++ b/test/fixtures/module-reexports-aliased-source-tracking/output.json
@@ -90,10 +90,10 @@
 				"description": "The root component for an alert dialog.",
 				"tags": []
 			},
+			"reexportedFrom": "AlertDialogRoot",
 			"isValue": true,
 			"isType": false,
-			"isNamespace": true,
-			"reexportedFrom": "AlertDialogRoot"
+			"isNamespace": true
 		},
 		{
 			"name": "AlertDialog.Root.Props",
@@ -180,14 +180,14 @@
 					}
 				]
 			},
-			"isValue": false,
-			"isType": true,
-			"isNamespace": false,
 			"extendsTypes": [
 				{
 					"name": "AlertDialogRootProps"
 				}
-			]
+			],
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "AlertDialog.Trigger",
@@ -240,10 +240,10 @@
 				"description": "A button that opens the dialog.",
 				"tags": []
 			},
+			"reexportedFrom": "DialogTrigger",
 			"isValue": true,
 			"isType": false,
-			"isNamespace": true,
-			"reexportedFrom": "DialogTrigger"
+			"isNamespace": true
 		},
 		{
 			"name": "AlertDialog.Trigger.Props",
@@ -292,14 +292,14 @@
 					}
 				]
 			},
-			"isValue": false,
-			"isType": true,
-			"isNamespace": false,
 			"extendsTypes": [
 				{
 					"name": "DialogTriggerProps"
 				}
-			]
+			],
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "AlertDialog.Backdrop",
@@ -337,10 +337,10 @@
 				"description": "An overlay that covers the page behind the dialog.",
 				"tags": []
 			},
+			"reexportedFrom": "DialogBackdrop",
 			"isValue": true,
 			"isType": false,
-			"isNamespace": true,
-			"reexportedFrom": "DialogBackdrop"
+			"isNamespace": true
 		},
 		{
 			"name": "AlertDialog.Backdrop.Props",
@@ -374,14 +374,14 @@
 					}
 				]
 			},
-			"isValue": false,
-			"isType": true,
-			"isNamespace": false,
 			"extendsTypes": [
 				{
 					"name": "DialogBackdropProps"
 				}
-			]
+			],
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/module-reexports-basic/output.json
+++ b/test/fixtures/module-reexports-basic/output.json
@@ -65,10 +65,10 @@
 					}
 				]
 			},
+			"reexportedFrom": "RootComponent",
 			"isValue": true,
 			"isType": false,
-			"isNamespace": true,
-			"reexportedFrom": "RootComponent"
+			"isNamespace": true
 		},
 		{
 			"name": "Root.Props",

--- a/test/fixtures/module-reexports-basic/output.json
+++ b/test/fixtures/module-reexports-basic/output.json
@@ -17,7 +17,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "Root",
@@ -62,6 +65,9 @@
 					}
 				]
 			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": true,
 			"reexportedFrom": "RootComponent"
 		},
 		{
@@ -107,7 +113,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Root.State",
@@ -131,7 +140,10 @@
 						"value": "\"error\""
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "RootProps",
@@ -175,7 +187,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "RootState",
@@ -198,7 +213,10 @@
 						"value": "\"error\""
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Source.RootComponent",
@@ -243,7 +261,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": true
 		},
 		{
 			"name": "Source.RootComponent.Props",
@@ -288,7 +309,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Source.RootComponent.State",
@@ -312,7 +336,10 @@
 						"value": "\"error\""
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Source.RootProps",
@@ -357,7 +384,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Source.RootState",
@@ -381,7 +411,10 @@
 						"value": "\"error\""
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/module-reexports-parts-namespace/output.json
+++ b/test/fixtures/module-reexports-parts-namespace/output.json
@@ -235,6 +235,9 @@
 				"description": "A simple component that displays a title and optional children.",
 				"tags": []
 			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": true,
 			"reexportedFrom": "ComponentRoot"
 		},
 		{
@@ -271,7 +274,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Component.Root.Props",
@@ -502,7 +508,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Component.Root.ChangeEventDetails",
@@ -594,7 +603,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Component.Part",
@@ -659,6 +671,9 @@
 				"description": "A simple component that displays a title and optional children.",
 				"tags": []
 			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": true,
 			"reexportedFrom": "ComponentPart"
 		},
 		{
@@ -695,7 +710,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Component.Part.Props",
@@ -755,7 +773,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Component.Handle",
@@ -888,6 +909,9 @@
 				"description": "A handle to control a Component imperatively.",
 				"tags": []
 			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false,
 			"reexportedFrom": "ComponentHandle"
 		},
 		{
@@ -994,6 +1018,9 @@
 				"description": "Creates a new handle to connect a Component.Root with detached triggers.",
 				"tags": []
 			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false,
 			"reexportedFrom": "createComponentHandle"
 		},
 		{
@@ -1125,7 +1152,10 @@
 			"documentation": {
 				"description": "A handle to control a Component imperatively.",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "ComponentRootState",
@@ -1160,7 +1190,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "ComponentRootChangeEventDetails",
@@ -1251,7 +1284,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "ComponentRootProps",
@@ -1481,7 +1517,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "ComponentPartState",
@@ -1516,7 +1555,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "ComponentPartProps",
@@ -1575,7 +1617,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/module-reexports-parts-namespace/output.json
+++ b/test/fixtures/module-reexports-parts-namespace/output.json
@@ -235,10 +235,10 @@
 				"description": "A simple component that displays a title and optional children.",
 				"tags": []
 			},
+			"reexportedFrom": "ComponentRoot",
 			"isValue": true,
 			"isType": false,
-			"isNamespace": true,
-			"reexportedFrom": "ComponentRoot"
+			"isNamespace": true
 		},
 		{
 			"name": "Component.Root.State",
@@ -671,10 +671,10 @@
 				"description": "A simple component that displays a title and optional children.",
 				"tags": []
 			},
+			"reexportedFrom": "ComponentPart",
 			"isValue": true,
 			"isType": false,
-			"isNamespace": true,
-			"reexportedFrom": "ComponentPart"
+			"isNamespace": true
 		},
 		{
 			"name": "Component.Part.State",
@@ -909,10 +909,10 @@
 				"description": "A handle to control a Component imperatively.",
 				"tags": []
 			},
+			"reexportedFrom": "ComponentHandle",
 			"isValue": true,
 			"isType": true,
-			"isNamespace": false,
-			"reexportedFrom": "ComponentHandle"
+			"isNamespace": false
 		},
 		{
 			"name": "Component.createHandle",
@@ -1018,10 +1018,10 @@
 				"description": "Creates a new handle to connect a Component.Root with detached triggers.",
 				"tags": []
 			},
+			"reexportedFrom": "createComponentHandle",
 			"isValue": true,
 			"isType": false,
-			"isNamespace": false,
-			"reexportedFrom": "createComponentHandle"
+			"isNamespace": false
 		},
 		{
 			"name": "ComponentHandle",
@@ -1153,7 +1153,7 @@
 				"description": "A handle to control a Component imperatively.",
 				"tags": []
 			},
-			"isValue": true,
+			"isValue": false,
 			"isType": true,
 			"isNamespace": false
 		},

--- a/test/fixtures/namespace-callback-alias-resolution/output.json
+++ b/test/fixtures/namespace-callback-alias-resolution/output.json
@@ -57,7 +57,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/namespace-export-resolution/output.json
+++ b/test/fixtures/namespace-export-resolution/output.json
@@ -137,7 +137,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "acceptsNamespacedType",
@@ -177,7 +180,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "Root.rootFunction",
@@ -196,7 +202,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "Root.Sub.nestedParams",
@@ -335,7 +344,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "Root.Sub.NestedComponent",
@@ -346,7 +358,10 @@
 					"namespaces": ["Root", "Sub"]
 				},
 				"props": []
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "Root.Sub.useHook",
@@ -382,7 +397,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "Root.Sub.Params",
@@ -500,7 +518,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Root.Sub.Grade",
@@ -520,7 +541,10 @@
 					}
 				],
 				"kind": "enum"
-			}
+			},
+			"isValue": true,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Root.NamespacedType",
@@ -540,7 +564,10 @@
 						"value": "\"two\""
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Other.Orientation",
@@ -560,7 +587,10 @@
 						"value": "\"vertical\""
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/namespace-nested-alias-resolution/output.json
+++ b/test/fixtures/namespace-nested-alias-resolution/output.json
@@ -52,7 +52,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "Root.Foo",
@@ -72,7 +75,10 @@
 						"value": "\"b\""
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Root.Nested.Foo",
@@ -92,7 +98,10 @@
 						"value": "\"b\""
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Root.Props",
@@ -146,7 +155,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	],
 	"imports": ["./types"]

--- a/test/fixtures/nested-function-union-any-deduplication/output.json
+++ b/test/fixtures/nested-function-union-any-deduplication/output.json
@@ -78,7 +78,10 @@
 			"documentation": {
 				"description": "Higher-order edge case: outer function parameters are unions of function\ntypes, and one outer overload uses `any` directly as a parameter type.\n\nNote: TypeScript simplifies `((y: any) => void) | ((y: string) => void)` to\njust `(y: string) => void` at the type level (the any-variant absorbs the\nstring-variant). So to test nested function-union matching with wildcard any,\nwe use `any` at the outer parameter level instead.\n\nCase 1 (CollapseViaAny): One outer overload has (x: any) => void which\n  matches (x: ((y: string) => void) | ((y: number) => void)) => void\n  via the any wildcard. Should collapse to 1 (preferring the concrete one).\n\nCase 2 (NestedUnionReorder): Two overloads with identical inner union\n  members in different order. Should collapse to 1 member.\n\nCase 3 (NotEquivalent): Two overloads with genuinely different inner\n  union members. Must stay 2 members.",
 				"tags": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "NestedUnionReorder",
@@ -153,7 +156,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "NotEquivalent",
@@ -292,7 +298,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/object-property-count-limit-scope/output.json
+++ b/test/fixtures/object-property-count-limit-scope/output.json
@@ -942,7 +942,10 @@
 			"documentation": {
 				"description": "A component whose props exceed the default property-count limit.",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "ManyComponentProps",
@@ -1918,7 +1921,10 @@
 			"documentation": {
 				"description": "Aggregates more than 50 properties through composition alone. Real-world\ncomponent props reach the same shape through wrappers such as\n`Omit<Partial<ManyProps> & ExtraProps, 'p51'>`.",
 				"tags": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/react-component-function-declaration/output.json
+++ b/test/fixtures/react-component-function-declaration/output.json
@@ -27,7 +27,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/react-component-function-overloads/output.json
+++ b/test/fixtures/react-component-function-overloads/output.json
@@ -103,7 +103,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/react-component-function-variable/output.json
+++ b/test/fixtures/react-component-function-variable/output.json
@@ -44,7 +44,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "TestComponent2",
@@ -137,7 +140,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "TestComponent3",
@@ -230,7 +236,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/react-component-generic-function-overloads/output.json
+++ b/test/fixtures/react-component-generic-function-overloads/output.json
@@ -103,7 +103,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/react-component-overload-any-callback-deduplication/output.json
+++ b/test/fixtures/react-component-overload-any-callback-deduplication/output.json
@@ -229,7 +229,10 @@
 			"documentation": {
 				"description": "Component with overloads where one overload results in `any` for ItemValue\nand the other results in a concrete type.\nTests that callbacks with `any` params are deduplicated in favor of concrete types.",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/react-component-render-callback-props/output.json
+++ b/test/fixtures/react-component-render-callback-props/output.json
@@ -211,7 +211,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "AccordionHeaderProps",
@@ -445,7 +448,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/react-component-return-types/output.json
+++ b/test/fixtures/react-component-return-types/output.json
@@ -27,7 +27,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "BareElement",
@@ -55,7 +58,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "GenericElement",
@@ -83,7 +89,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "BareNode",
@@ -111,7 +120,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "NullableElement",
@@ -139,7 +151,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "InferredElement",
@@ -167,7 +182,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "LocalElementType",
@@ -228,7 +246,10 @@
 			"documentation": {
 				"description": "A local type whose name merely ends in `Element` does not make a component.",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "DomElementType",
@@ -279,7 +300,10 @@
 			"documentation": {
 				"description": "Neither does a DOM element.",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react", "react"]

--- a/test/fixtures/react-component-union-variants/output.json
+++ b/test/fixtures/react-component-union-variants/output.json
@@ -144,7 +144,10 @@
 			"documentation": {
 				"description": "A toolbar that renders either its own root element or a caller-supplied one.",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "OptionalToolbar",
@@ -383,7 +386,10 @@
 			"documentation": {
 				"description": "Not every union of a component is a component: an arm that is not itself\ncomponent-like keeps the export a plain union.",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/react-event-handlers/output.json
+++ b/test/fixtures/react-event-handlers/output.json
@@ -116,7 +116,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/react-forward-ref-component/output.json
+++ b/test/fixtures/react-forward-ref-component/output.json
@@ -155,7 +155,10 @@
 			"documentation": {
 				"description": "A test component",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/react-forward-ref-union-props/output.json
+++ b/test/fixtures/react-forward-ref-union-props/output.json
@@ -449,7 +449,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/react-hook-arrow-function/output.json
+++ b/test/fixtures/react-hook-arrow-function/output.json
@@ -141,7 +141,10 @@
 				"description": "A hook defined as an arrow function.",
 				"visibility": "internal",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/react-hook-function-declaration/output.json
+++ b/test/fixtures/react-hook-function-declaration/output.json
@@ -144,7 +144,10 @@
 				"description": "A hook defined as a function.",
 				"visibility": "internal",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/react-hook-function-expression/output.json
+++ b/test/fixtures/react-hook-function-expression/output.json
@@ -144,7 +144,10 @@
 				"description": "A hook defined as a function expression.",
 				"visibility": "internal",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/react-hook-multiple-parameters/output.json
+++ b/test/fixtures/react-hook-multiple-parameters/output.json
@@ -89,7 +89,10 @@
 				"description": "A hook defined as a function.",
 				"visibility": "internal",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/react-hook-overload-signatures/output.json
+++ b/test/fixtures/react-hook-overload-signatures/output.json
@@ -54,7 +54,10 @@
 			"documentation": {
 				"description": "Returns the input string.",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/react-memo-component/output.json
+++ b/test/fixtures/react-memo-component/output.json
@@ -96,7 +96,10 @@
 			"documentation": {
 				"description": "A test component",
 				"tags": []
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/react-mui-overridable-component/output.json
+++ b/test/fixtures/react-mui-overridable-component/output.json
@@ -830,7 +830,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/react-props-callback-types/output.json
+++ b/test/fixtures/react-props-callback-types/output.json
@@ -156,7 +156,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/react-props-literal-types/output.json
+++ b/test/fixtures/react-props-literal-types/output.json
@@ -42,7 +42,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/react-props-optional-types/output.json
+++ b/test/fixtures/react-props-optional-types/output.json
@@ -77,7 +77,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/react-refs/output.json
+++ b/test/fixtures/react-refs/output.json
@@ -147,7 +147,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/readonly-array-mapped-alias-wrapped/output.json
+++ b/test/fixtures/readonly-array-mapped-alias-wrapped/output.json
@@ -54,7 +54,10 @@
 						]
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "Wrapped",
@@ -173,7 +176,10 @@
 					}
 				},
 				"isReadonly": true
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/readonly-array-mapped-type-any-value/output.json
+++ b/test/fixtures/readonly-array-mapped-type-any-value/output.json
@@ -64,7 +64,10 @@
 					}
 				},
 				"isReadonly": true
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/readonly-array-mapped-type-as-clause/output.json
+++ b/test/fixtures/readonly-array-mapped-type-as-clause/output.json
@@ -22,7 +22,10 @@
 					"properties": []
 				},
 				"isReadonly": true
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/readonly-array-mapped-type-key-no-default/output.json
+++ b/test/fixtures/readonly-array-mapped-type-key-no-default/output.json
@@ -64,7 +64,10 @@
 					}
 				},
 				"isReadonly": true
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/readonly-array-mapped-type-literal-key/output.json
+++ b/test/fixtures/readonly-array-mapped-type-literal-key/output.json
@@ -56,7 +56,10 @@
 					]
 				},
 				"isReadonly": true
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "ParametricData",
@@ -79,7 +82,10 @@
 					"properties": []
 				},
 				"isReadonly": true
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/readonly-array-mapped-type-non-optional/output.json
+++ b/test/fixtures/readonly-array-mapped-type-non-optional/output.json
@@ -46,7 +46,10 @@
 					}
 				},
 				"isReadonly": true
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/readonly-array-mapped-type-number-key/output.json
+++ b/test/fixtures/readonly-array-mapped-type-number-key/output.json
@@ -64,7 +64,10 @@
 					}
 				},
 				"isReadonly": true
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/readonly-array-mapped-type-plus-optional/output.json
+++ b/test/fixtures/readonly-array-mapped-type-plus-optional/output.json
@@ -64,7 +64,10 @@
 					}
 				},
 				"isReadonly": true
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/readonly-array-mapped-type-strip-optional/output.json
+++ b/test/fixtures/readonly-array-mapped-type-strip-optional/output.json
@@ -46,7 +46,10 @@
 					}
 				},
 				"isReadonly": true
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/readonly-array-mapped-type-template-literal-constraint/output.json
+++ b/test/fixtures/readonly-array-mapped-type-template-literal-constraint/output.json
@@ -22,7 +22,10 @@
 					"properties": []
 				},
 				"isReadonly": true
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/readonly-array-mapped-type-union-default/output.json
+++ b/test/fixtures/readonly-array-mapped-type-union-default/output.json
@@ -82,7 +82,10 @@
 					}
 				},
 				"isReadonly": true
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/readonly-array-mapped-type-value-no-default/output.json
+++ b/test/fixtures/readonly-array-mapped-type-value-no-default/output.json
@@ -56,7 +56,10 @@
 					}
 				},
 				"isReadonly": true
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/readonly-array-mapped-type-with-concrete-props/output.json
+++ b/test/fixtures/readonly-array-mapped-type-with-concrete-props/output.json
@@ -120,7 +120,10 @@
 					]
 				},
 				"isReadonly": true
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/readonly-array-mapped-type/output.json
+++ b/test/fixtures/readonly-array-mapped-type/output.json
@@ -64,7 +64,10 @@
 					}
 				},
 				"isReadonly": true
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/symbol-double-underscore-name-preservation/output.json
+++ b/test/fixtures/symbol-double-underscore-name-preservation/output.json
@@ -50,7 +50,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "__Named",
@@ -69,7 +72,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/type-alias-basic-resolution/output.json
+++ b/test/fixtures/type-alias-basic-resolution/output.json
@@ -245,7 +245,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "AliasContainer",
@@ -463,7 +466,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/type-alias-export-preservation/output.json
+++ b/test/fixtures/type-alias-export-preservation/output.json
@@ -42,7 +42,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "processWithObjectAlias",
@@ -89,14 +92,20 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "SimpleAlias",
 			"type": {
 				"kind": "intrinsic",
 				"intrinsic": "string"
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "UnionAlias",
@@ -119,7 +128,10 @@
 						"value": "\"c\""
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "ObjectAlias",
@@ -146,7 +158,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "GenericAlias",
@@ -182,7 +197,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "ConditionalAlias",
@@ -198,7 +216,10 @@
 						"value": "\"other\""
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "ExtendedAlias",
@@ -256,7 +277,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/type-alias-generic-argument-resolution/output.json
+++ b/test/fixtures/type-alias-generic-argument-resolution/output.json
@@ -83,7 +83,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/type-alias-union-member-resolution/output.json
+++ b/test/fixtures/type-alias-union-member-resolution/output.json
@@ -50,7 +50,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "Props",
@@ -93,7 +96,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/type-array-syntax-resolution/output.json
+++ b/test/fixtures/type-array-syntax-resolution/output.json
@@ -92,7 +92,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "acceptsArrayParameters",
@@ -133,7 +136,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/type-conditional-return-and-props/output.json
+++ b/test/fixtures/type-conditional-return-and-props/output.json
@@ -49,7 +49,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "ConditionalPropsComponent",
@@ -127,7 +130,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/type-cycle-recursive-resolution/output.json
+++ b/test/fixtures/type-cycle-recursive-resolution/output.json
@@ -80,7 +80,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "testUnion",
@@ -165,7 +168,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "testIntersection",
@@ -251,7 +257,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "testArray",
@@ -310,7 +319,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "testTuple",
@@ -372,7 +384,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "TestObject1",
@@ -475,7 +490,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "TestObject2",
@@ -557,7 +575,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/type-extract-utility-resolution/output.json
+++ b/test/fixtures/type-extract-utility-resolution/output.json
@@ -6,14 +6,20 @@
 			"type": {
 				"kind": "intrinsic",
 				"intrinsic": "string"
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "StringValues",
 			"type": {
 				"kind": "intrinsic",
 				"intrinsic": "string"
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "KeepStrings",
@@ -29,7 +35,10 @@
 						"kind": "typeParameter"
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/type-index-signature-resolution/output.json
+++ b/test/fixtures/type-index-signature-resolution/output.json
@@ -75,7 +75,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "returnsIndexSignature",
@@ -101,7 +104,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "MyComponent",
@@ -154,7 +160,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "StringIndexType",
@@ -172,7 +181,10 @@
 						"intrinsic": "number"
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "NumberIndexType",
@@ -190,7 +202,10 @@
 						"intrinsic": "string"
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "TypeWithCustomKeyName",
@@ -208,7 +223,10 @@
 						"intrinsic": "number"
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "TypeWithNestedCustomKey",
@@ -235,7 +253,10 @@
 						]
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "SimpleIndex",
@@ -253,7 +274,10 @@
 						"intrinsic": "boolean"
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "VariantExtraFiles",
@@ -289,7 +313,10 @@
 						]
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "OuterType",
@@ -316,7 +343,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "MixedType",
@@ -352,7 +382,10 @@
 						]
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "IndexedInterface",
@@ -370,7 +403,10 @@
 						"intrinsic": "unknown"
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "MyType",
@@ -406,7 +442,10 @@
 						]
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "HelperType",
@@ -442,7 +481,10 @@
 						]
 					}
 				}
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "MyInterface",
@@ -490,7 +532,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	],
 	"imports": ["./helper"]

--- a/test/fixtures/type-indexed-access-union-resolution/output.json
+++ b/test/fixtures/type-indexed-access-union-resolution/output.json
@@ -34,7 +34,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "Props",
@@ -78,7 +81,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/type-intersection-resolution/output.json
+++ b/test/fixtures/type-intersection-resolution/output.json
@@ -128,7 +128,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "aliasedIntersection",
@@ -260,7 +263,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "intersectionWithMethod",
@@ -376,7 +382,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/type-intrinsic-props-resolution/output.json
+++ b/test/fixtures/type-intrinsic-props-resolution/output.json
@@ -42,7 +42,10 @@
 						"optional": false
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/type-literal-union-resolution/output.json
+++ b/test/fixtures/type-literal-union-resolution/output.json
@@ -264,7 +264,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "acceptsLiteralUnionParameters",
@@ -467,7 +470,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "acceptsKeyofProp",
@@ -535,7 +541,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/type-never-resolution/output.json
+++ b/test/fixtures/type-never-resolution/output.json
@@ -26,14 +26,20 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "Impossible",
 			"type": {
 				"kind": "intrinsic",
 				"intrinsic": "never"
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/type-object-shape-resolution/output.json
+++ b/test/fixtures/type-object-shape-resolution/output.json
@@ -60,7 +60,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "acceptsNamedObjectTypes",
@@ -130,7 +133,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "acceptsObjectProps",
@@ -254,7 +260,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/type-record-resolution/output.json
+++ b/test/fixtures/type-record-resolution/output.json
@@ -44,7 +44,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/type-reference-vs-inline-resolution/output.json
+++ b/test/fixtures/type-reference-vs-inline-resolution/output.json
@@ -91,7 +91,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "inlineTypes",
@@ -144,7 +147,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/type-tuple-resolution/output.json
+++ b/test/fixtures/type-tuple-resolution/output.json
@@ -26,7 +26,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "testFunction2",
@@ -53,7 +56,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "testFunction3",
@@ -83,7 +89,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "testFunction4",
@@ -113,7 +122,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/type-union-object-props-resolution/output.json
+++ b/test/fixtures/type-union-object-props-resolution/output.json
@@ -86,7 +86,10 @@
 						"optional": true
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	],
 	"imports": ["react"]

--- a/test/fixtures/type-utility-types-resolution/output.json
+++ b/test/fixtures/type-utility-types-resolution/output.json
@@ -117,7 +117,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "acceptsOmittedProps",
@@ -226,7 +229,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "acceptsParameterTuple",
@@ -349,7 +355,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		},
 		{
 			"name": "acceptsReturnType",
@@ -376,7 +385,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": true,
+			"isType": false,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/union-any-wildcard-order/output.json
+++ b/test/fixtures/union-any-wildcard-order/output.json
@@ -44,7 +44,10 @@
 			"documentation": {
 				"description": "Tests that union/intersection multiset matching is order-independent.\n\nCase 1 (OrderIndependent): Two overloads whose parameter is the same union\nwith members in different order (`string | number` vs `number | string`).\nShould collapse to 1 member.\n\nCase 2 (AnyWildcardDedup): One overload has `any` parameter (TypeScript\nsimplifies `any | string` to `any`), the other has `string | number`.\nThe `any` wildcard matches a concrete type, so they collapse to 1 member\n(the non-any version is preferred).\n\nCase 3 (NotEquivalent): Two overloads with genuinely different unions\n(`string | number` vs `string | boolean`). Must NOT collapse.",
 				"tags": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "AnyWildcardDedup",
@@ -85,7 +88,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "AnyWildcardDedupReversed",
@@ -126,7 +132,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "NotEquivalent",
@@ -197,7 +206,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/union-never-reduction/output.json
+++ b/test/fixtures/union-never-reduction/output.json
@@ -38,7 +38,10 @@
 			"documentation": {
 				"description": "`never` should be removed from unions when other members are present.",
 				"tags": []
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		},
 		{
 			"name": "OnValueChange",
@@ -102,7 +105,10 @@
 						}
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }

--- a/test/fixtures/unresolved-indexed-access-fallback/output.json
+++ b/test/fixtures/unresolved-indexed-access-fallback/output.json
@@ -107,7 +107,10 @@
 						]
 					}
 				]
-			}
+			},
+			"isValue": false,
+			"isType": true,
+			"isNamespace": false
 		}
 	]
 }


### PR DESCRIPTION
Consumers can't tell a runtime constant from a type declaration: `export type X = 'x'` and `export const x: X = 'x'` resolve to the same literal node. James ran into this in his review of mui/mui-public#1713 (https://github.com/mui/mui-public/pull/1713#issuecomment-5394142351), where the docs pipeline can silently invent or drop documented constants because of it.

This adds `isValue`, `isType`, and `isNamespace` to `ExportNode` — the declaration spaces of the export's symbol, alias-resolved. The spaces are a closed set, so the flags stay stable as the parser learns new syntax, and merged declarations (class, enum, `interface X` + `const X`, an import merged with a local interface) simply set several flags. Type-only re-exports (`export type { X }`, `export type * from`) never occupy the value space, and `isNamespace` requires an actual namespace declaration — expando assignments (`fn.extra = ...`) don't count.